### PR TITLE
Fix avg display in voltage page

### DIFF
--- a/lib/obp60task/PageVoltage.cpp
+++ b/lib/obp60task/PageVoltage.cpp
@@ -171,7 +171,7 @@ public:
         // Show average settings
         getdisplay().setTextColor(textcolor);
         getdisplay().setFont(&Ubuntu_Bold8pt7b);
-        getdisplay().setCursor(320, 100);
+        getdisplay().setCursor(320, 84);
         switch (average) {
             case 0:
                 getdisplay().print("Avg: 1s");


### PR DESCRIPTION
Move avg text up to avoid overlapping