### PR TITLE
PageRollPitch now accepts 2 config options, converted perl script to python

### DIFF
--- a/lib/obp60task/PageRollPitch.cpp
+++ b/lib/obp60task/PageRollPitch.cpp
@@ -342,9 +342,9 @@ static Page *createPage(CommonData &common){
 PageDescription registerPageRollPitch(
     "RollPitch",        // Page name
     createPage,         // Action
-    0,                  // Number of bus values depends on selection in Web configuration
+    2,                  // Number of bus values depends on selection in Web configuration
    // {"xdrROLL", "xdrPTCH"},// Bus values we need in the page
-    {"xdrRoll", "xdrPitch"},// Bus values we need in the page
+    //{"xdrRoll", "xdrPitch"},// Bus values we need in the page
     true                // Show display header on/off
 );
 

--- a/lib/obp60task/PageWindRoseFlex.cpp
+++ b/lib/obp60task/PageWindRoseFlex.cpp
@@ -186,7 +186,8 @@ public:
         getdisplay().setFont(&DSEG7Classic_BoldItalic20pt7b);
         getdisplay().setCursor(295, 65);
         if(valid3 == true){
-            getdisplay().print(abs(value3 * 180 / PI), 0);   // Value
+           // getdisplay().print(abs(value3 * 180 / PI), 0);   // Value          
+            getdisplay().print(svalue3);     // Value
         }
         else{
             getdisplay().print("---");                   // Value

--- a/lib/obp60task/config.json
+++ b/lib/obp60task/config.json
@@ -920,11 +920,66 @@
         "type": "list",
         "default": "Voltage",
         "description": "Type of page for page 1",
-        "list":["OneValue","TwoValues","ThreeValues","FourValues","FourValues2","ApparentWind","WindRose","WindRoseFlex","Voltage","DST810","Clock","WhitePage","BME280","RudderPosition","KeelPosition","Battery","Battery2","RollPitch","Solar","Generator","XTETrack","Fluid"],
+        "list": [
+            "ApparentWind",
+            "BME280",
+            "Battery",
+            "Battery2",
+            "Clock",
+            "DST810",
+            "Fluid",
+            "FourValues",
+            "FourValues2",
+            "Generator",
+            "KeelPosition",
+            "OneValue",
+            "RollPitch",
+            "RudderPosition",
+            "Solar",
+            "ThreeValues",
+            "TwoValues",
+            "Voltage",
+            "White",
+            "WindRose",
+            "WindRoseFlex",
+            "XTETrack"
+        ],
         "category": "OBP60 Page 1",
         "capabilities": {
-            "obp60":"true"
-        }
+            "obp60": "true"
+        },
+        "condition": [
+            {
+                "visiblePages": 1
+            },
+            {
+                "visiblePages": 2
+            },
+            {
+                "visiblePages": 3
+            },
+            {
+                "visiblePages": 4
+            },
+            {
+                "visiblePages": 5
+            },
+            {
+                "visiblePages": 6
+            },
+            {
+                "visiblePages": 7
+            },
+            {
+                "visiblePages": 8
+            },
+            {
+                "visiblePages": 9
+            },
+            {
+                "visiblePages": 10
+            }
+        ]
     },
     {
         "name": "page1value1",
@@ -934,9 +989,31 @@
         "description": "The display for field one",
         "category": "OBP60 Page 1",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page1type":"OneValue"},{"page1type":"TwoValues"},{"page1type":"ThreeValues"},{"page1type":"FourValues"},{"page1type":"FourValues2"},{"page1type":"WindRoseFlex"},{"page1type":"Fluid"}]
+        "condition": [
+            {
+                "page1type": "FourValues"
+            },
+            {
+                "page1type": "FourValues2"
+            },
+            {
+                "page1type": "OneValue"
+            },
+            {
+                "page1type": "RollPitch"
+            },
+            {
+                "page1type": "ThreeValues"
+            },
+            {
+                "page1type": "TwoValues"
+            },
+            {
+                "page1type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page1value2",
@@ -946,57 +1023,107 @@
         "description": "The display for field two",
         "category": "OBP60 Page 1",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page1type":"TwoValues"},{"page1type":"ThreeValues"},{"page1type":"FourValues"},{"page1type":"FourValues2"},{"page1type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page1type": "FourValues"
+            },
+            {
+                "page1type": "FourValues2"
+            },
+            {
+                "page1type": "RollPitch"
+            },
+            {
+                "page1type": "ThreeValues"
+            },
+            {
+                "page1type": "TwoValues"
+            },
+            {
+                "page1type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page1value3",
         "label": "Field 3",
         "type": "boatData",
         "default": "",
-        "description": "The display for field 3",
+        "description": "The display for field three",
         "category": "OBP60 Page 1",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page1type":"ThreeValues"},{"page1type":"FourValues"},{"page1type":"FourValues2"},{"page1type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page1type": "FourValues"
+            },
+            {
+                "page1type": "FourValues2"
+            },
+            {
+                "page1type": "ThreeValues"
+            },
+            {
+                "page1type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page1value4",
         "label": "Field 4",
         "type": "boatData",
         "default": "",
-        "description": "The display for field 4",
+        "description": "The display for field four",
         "category": "OBP60 Page 1",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page1type":"FourValues"},{"page1type":"FourValues2"},{"page1type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page1type": "FourValues"
+            },
+            {
+                "page1type": "FourValues2"
+            },
+            {
+                "page1type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page1value5",
         "label": "Field 5",
         "type": "boatData",
         "default": "",
-        "description": "The display for field 5",
+        "description": "The display for field five",
         "category": "OBP60 Page 1",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page1type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page1type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page1value6",
         "label": "Field 6",
         "type": "boatData",
         "default": "",
-        "description": "The display for field 6",
+        "description": "The display for field six",
         "category": "OBP60 Page 1",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page1type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page1type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page1fluid",
@@ -1004,20 +1131,45 @@
         "type": "list",
         "default": "0",
         "list": [
-            {"l":"Fuel (0)","v":"0"},
-            {"l":"Water (1)","v":"1"},
-            {"l":"Gray Water (2)","v":"2"},
-            {"l":"Live Well (3)","v":"3"},
-            {"l":"Oil (4)","v":"4"},
-            {"l":"Black Water (5)","v":"5"},
-            {"l":"Fuel Gasoline (6)","v":"6"}
+            {
+                "l": "Fuel (0)",
+                "v": "0"
+            },
+            {
+                "l": "Water (1)",
+                "v": "1"
+            },
+            {
+                "l": "Gray Water (2)",
+                "v": "2"
+            },
+            {
+                "l": "Live Well (3)",
+                "v": "3"
+            },
+            {
+                "l": "Oil (4)",
+                "v": "4"
+            },
+            {
+                "l": "Black Water (5)",
+                "v": "5"
+            },
+            {
+                "l": "Fuel Gasoline (6)",
+                "v": "6"
+            }
         ],
         "description": "Fluid type in tank",
         "category": "OBP60 Page 1",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page1type":"Fluid"}]
+        "condition": [
+            {
+                "page1type": "Fluid"
+            }
+        ]
     },
     {
         "name": "page2type",
@@ -1025,12 +1177,63 @@
         "type": "list",
         "default": "WindRose",
         "description": "Type of page for page 2",
-        "list":["OneValue","TwoValues","ThreeValues","FourValues","FourValues2","ApparentWind","WindRose","WindRoseFlex","Voltage","DST810","Clock","WhitePage","BME280","RudderPosition","KeelPosition","Battery","Battery2","RollPitch","Solar","Generator","XTETrack","Fluid"],
+        "list": [
+            "ApparentWind",
+            "BME280",
+            "Battery",
+            "Battery2",
+            "Clock",
+            "DST810",
+            "Fluid",
+            "FourValues",
+            "FourValues2",
+            "Generator",
+            "KeelPosition",
+            "OneValue",
+            "RollPitch",
+            "RudderPosition",
+            "Solar",
+            "ThreeValues",
+            "TwoValues",
+            "Voltage",
+            "White",
+            "WindRose",
+            "WindRoseFlex",
+            "XTETrack"
+        ],
         "category": "OBP60 Page 2",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"visiblePages":"2"},{"visiblePages":"3"},{"visiblePages":"4"},{"visiblePages":"5"},{"visiblePages":"6"},{"visiblePages":"7"},{"visiblePages":"8"},{"visiblePages":"9"},{"visiblePages":"10"}]
+        "condition": [
+            {
+                "visiblePages": 2
+            },
+            {
+                "visiblePages": 3
+            },
+            {
+                "visiblePages": 4
+            },
+            {
+                "visiblePages": 5
+            },
+            {
+                "visiblePages": 6
+            },
+            {
+                "visiblePages": 7
+            },
+            {
+                "visiblePages": 8
+            },
+            {
+                "visiblePages": 9
+            },
+            {
+                "visiblePages": 10
+            }
+        ]
     },
     {
         "name": "page2value1",
@@ -1040,9 +1243,31 @@
         "description": "The display for field one",
         "category": "OBP60 Page 2",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page2type":"OneValue"},{"page2type":"TwoValues"},{"page2type":"ThreeValues"},{"page2type":"FourValues"},{"page2type":"FourValues2"},{"page2type":"WindRoseFlex"},{"page2type":"Fluid"}]
+        "condition": [
+            {
+                "page2type": "FourValues"
+            },
+            {
+                "page2type": "FourValues2"
+            },
+            {
+                "page2type": "OneValue"
+            },
+            {
+                "page2type": "RollPitch"
+            },
+            {
+                "page2type": "ThreeValues"
+            },
+            {
+                "page2type": "TwoValues"
+            },
+            {
+                "page2type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page2value2",
@@ -1052,57 +1277,107 @@
         "description": "The display for field two",
         "category": "OBP60 Page 2",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page2type":"TwoValues"},{"page2type":"ThreeValues"},{"page2type":"FourValues"},{"page2type":"FourValues2"},{"page2type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page2type": "FourValues"
+            },
+            {
+                "page2type": "FourValues2"
+            },
+            {
+                "page2type": "RollPitch"
+            },
+            {
+                "page2type": "ThreeValues"
+            },
+            {
+                "page2type": "TwoValues"
+            },
+            {
+                "page2type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page2value3",
         "label": "Field 3",
         "type": "boatData",
         "default": "",
-        "description": "The display for field 3",
+        "description": "The display for field three",
         "category": "OBP60 Page 2",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page2type":"ThreeValues"},{"page2type":"FourValues"},{"page2type":"FourValues2"},{"page2type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page2type": "FourValues"
+            },
+            {
+                "page2type": "FourValues2"
+            },
+            {
+                "page2type": "ThreeValues"
+            },
+            {
+                "page2type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page2value4",
         "label": "Field 4",
         "type": "boatData",
         "default": "",
-        "description": "The display for field 4",
+        "description": "The display for field four",
         "category": "OBP60 Page 2",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page2type":"FourValues"},{"page2type":"FourValues2"},{"page2type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page2type": "FourValues"
+            },
+            {
+                "page2type": "FourValues2"
+            },
+            {
+                "page2type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page2value5",
         "label": "Field 5",
         "type": "boatData",
         "default": "",
-        "description": "The display for field 5",
+        "description": "The display for field five",
         "category": "OBP60 Page 2",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page2type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page2type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page2value6",
         "label": "Field 6",
         "type": "boatData",
         "default": "",
-        "description": "The display for field 6",
+        "description": "The display for field six",
         "category": "OBP60 Page 2",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page2type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page2type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page2fluid",
@@ -1110,20 +1385,45 @@
         "type": "list",
         "default": "0",
         "list": [
-            {"l":"Fuel (0)","v":"0"},
-            {"l":"Water (1)","v":"1"},
-            {"l":"Gray Water (2)","v":"2"},
-            {"l":"Live Well (3)","v":"3"},
-            {"l":"Oil (4)","v":"4"},
-            {"l":"Black Water (5)","v":"5"},
-            {"l":"Fuel Gasoline (6)","v":"6"}
+            {
+                "l": "Fuel (0)",
+                "v": "0"
+            },
+            {
+                "l": "Water (1)",
+                "v": "1"
+            },
+            {
+                "l": "Gray Water (2)",
+                "v": "2"
+            },
+            {
+                "l": "Live Well (3)",
+                "v": "3"
+            },
+            {
+                "l": "Oil (4)",
+                "v": "4"
+            },
+            {
+                "l": "Black Water (5)",
+                "v": "5"
+            },
+            {
+                "l": "Fuel Gasoline (6)",
+                "v": "6"
+            }
         ],
         "description": "Fluid type in tank",
         "category": "OBP60 Page 2",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page2type":"Fluid"}]
+        "condition": [
+            {
+                "page2type": "Fluid"
+            }
+        ]
     },
     {
         "name": "page3type",
@@ -1131,24 +1431,94 @@
         "type": "list",
         "default": "OneValue",
         "description": "Type of page for page 3",
-        "list":["OneValue","TwoValues","ThreeValues","FourValues","FourValues2","ApparentWind","WindRose","WindRoseFlex","Voltage","DST810","Clock","WhitePage","BME280","RudderPosition","KeelPosition","Battery","Battery2","RollPitch","Solar","Generator","XTETrack","Fluid"],
+        "list": [
+            "ApparentWind",
+            "BME280",
+            "Battery",
+            "Battery2",
+            "Clock",
+            "DST810",
+            "Fluid",
+            "FourValues",
+            "FourValues2",
+            "Generator",
+            "KeelPosition",
+            "OneValue",
+            "RollPitch",
+            "RudderPosition",
+            "Solar",
+            "ThreeValues",
+            "TwoValues",
+            "Voltage",
+            "White",
+            "WindRose",
+            "WindRoseFlex",
+            "XTETrack"
+        ],
         "category": "OBP60 Page 3",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"visiblePages":"3"},{"visiblePages":"4"},{"visiblePages":"5"},{"visiblePages":"6"},{"visiblePages":"7"},{"visiblePages":"8"},{"visiblePages":"9"},{"visiblePages":"10"}]
+        "condition": [
+            {
+                "visiblePages": 3
+            },
+            {
+                "visiblePages": 4
+            },
+            {
+                "visiblePages": 5
+            },
+            {
+                "visiblePages": 6
+            },
+            {
+                "visiblePages": 7
+            },
+            {
+                "visiblePages": 8
+            },
+            {
+                "visiblePages": 9
+            },
+            {
+                "visiblePages": 10
+            }
+        ]
     },
     {
         "name": "page3value1",
         "label": "Field 1",
         "type": "boatData",
-        "default": "AWA",
+        "default": "",
         "description": "The display for field one",
         "category": "OBP60 Page 3",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page3type":"OneValue"},{"page3type":"TwoValues"},{"page3type":"ThreeValues"},{"page3type":"FourValues"},{"page3type":"FourValues2"},{"page3type":"WindRoseFlex"},{"page3type":"Fluid"}]
+        "condition": [
+            {
+                "page3type": "FourValues"
+            },
+            {
+                "page3type": "FourValues2"
+            },
+            {
+                "page3type": "OneValue"
+            },
+            {
+                "page3type": "RollPitch"
+            },
+            {
+                "page3type": "ThreeValues"
+            },
+            {
+                "page3type": "TwoValues"
+            },
+            {
+                "page3type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page3value2",
@@ -1158,57 +1528,107 @@
         "description": "The display for field two",
         "category": "OBP60 Page 3",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page3type":"TwoValues"},{"page3type":"ThreeValues"},{"page3type":"FourValues"},{"page3type":"FourValues2"},{"page3type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page3type": "FourValues"
+            },
+            {
+                "page3type": "FourValues2"
+            },
+            {
+                "page3type": "RollPitch"
+            },
+            {
+                "page3type": "ThreeValues"
+            },
+            {
+                "page3type": "TwoValues"
+            },
+            {
+                "page3type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page3value3",
         "label": "Field 3",
         "type": "boatData",
         "default": "",
-        "description": "The display for field 3",
+        "description": "The display for field three",
         "category": "OBP60 Page 3",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page3type":"ThreeValues"},{"page3type":"FourValues"},{"page3type":"FourValues2"},{"page3type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page3type": "FourValues"
+            },
+            {
+                "page3type": "FourValues2"
+            },
+            {
+                "page3type": "ThreeValues"
+            },
+            {
+                "page3type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page3value4",
         "label": "Field 4",
         "type": "boatData",
         "default": "",
-        "description": "The display for field 4",
+        "description": "The display for field four",
         "category": "OBP60 Page 3",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page3type":"FourValues"},{"page3type":"FourValues2"},{"page3type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page3type": "FourValues"
+            },
+            {
+                "page3type": "FourValues2"
+            },
+            {
+                "page3type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page3value5",
         "label": "Field 5",
         "type": "boatData",
         "default": "",
-        "description": "The display for field 5",
+        "description": "The display for field five",
         "category": "OBP60 Page 3",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page3type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page3type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page3value6",
         "label": "Field 6",
         "type": "boatData",
         "default": "",
-        "description": "The display for field 6",
+        "description": "The display for field six",
         "category": "OBP60 Page 3",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page3type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page3type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page3fluid",
@@ -1216,20 +1636,45 @@
         "type": "list",
         "default": "0",
         "list": [
-            {"l":"Fuel (0)","v":"0"},
-            {"l":"Water (1)","v":"1"},
-            {"l":"Gray Water (2)","v":"2"},
-            {"l":"Live Well (3)","v":"3"},
-            {"l":"Oil (4)","v":"4"},
-            {"l":"Black Water (5)","v":"5"},
-            {"l":"Fuel Gasoline (6)","v":"6"}
+            {
+                "l": "Fuel (0)",
+                "v": "0"
+            },
+            {
+                "l": "Water (1)",
+                "v": "1"
+            },
+            {
+                "l": "Gray Water (2)",
+                "v": "2"
+            },
+            {
+                "l": "Live Well (3)",
+                "v": "3"
+            },
+            {
+                "l": "Oil (4)",
+                "v": "4"
+            },
+            {
+                "l": "Black Water (5)",
+                "v": "5"
+            },
+            {
+                "l": "Fuel Gasoline (6)",
+                "v": "6"
+            }
         ],
         "description": "Fluid type in tank",
         "category": "OBP60 Page 3",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page3type":"Fluid"}]
+        "condition": [
+            {
+                "page3type": "Fluid"
+            }
+        ]
     },
     {
         "name": "page4type",
@@ -1237,84 +1682,201 @@
         "type": "list",
         "default": "TwoValues",
         "description": "Type of page for page 4",
-        "list":["OneValue","TwoValues","ThreeValues","FourValues","FourValues2","ApparentWind","WindRose","WindRoseFlex","Voltage","DST810","Clock","WhitePage","BME280","RudderPosition","KeelPosition","Battery","Battery2","RollPitch","Solar","Generator","XTETrack","Fluid"],
+        "list": [
+            "ApparentWind",
+            "BME280",
+            "Battery",
+            "Battery2",
+            "Clock",
+            "DST810",
+            "Fluid",
+            "FourValues",
+            "FourValues2",
+            "Generator",
+            "KeelPosition",
+            "OneValue",
+            "RollPitch",
+            "RudderPosition",
+            "Solar",
+            "ThreeValues",
+            "TwoValues",
+            "Voltage",
+            "White",
+            "WindRose",
+            "WindRoseFlex",
+            "XTETrack"
+        ],
         "category": "OBP60 Page 4",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"visiblePages":"4"},{"visiblePages":"5"},{"visiblePages":"6"},{"visiblePages":"7"},{"visiblePages":"8"},{"visiblePages":"9"},{"visiblePages":"10"}]
+        "condition": [
+            {
+                "visiblePages": 4
+            },
+            {
+                "visiblePages": 5
+            },
+            {
+                "visiblePages": 6
+            },
+            {
+                "visiblePages": 7
+            },
+            {
+                "visiblePages": 8
+            },
+            {
+                "visiblePages": 9
+            },
+            {
+                "visiblePages": 10
+            }
+        ]
     },
     {
         "name": "page4value1",
         "label": "Field 1",
         "type": "boatData",
-        "default": "STW",
+        "default": "",
         "description": "The display for field one",
         "category": "OBP60 Page 4",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page4type":"OneValue"},{"page4type":"TwoValues"},{"page4type":"ThreeValues"},{"page4type":"FourValues"},{"page4type":"FourValues2"},{"page4type":"WindRoseFlex"},{"page4type":"Fluid"}]
+        "condition": [
+            {
+                "page4type": "FourValues"
+            },
+            {
+                "page4type": "FourValues2"
+            },
+            {
+                "page4type": "OneValue"
+            },
+            {
+                "page4type": "RollPitch"
+            },
+            {
+                "page4type": "ThreeValues"
+            },
+            {
+                "page4type": "TwoValues"
+            },
+            {
+                "page4type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page4value2",
         "label": "Field 2",
         "type": "boatData",
-        "default": "DBT",
+        "default": "",
         "description": "The display for field two",
         "category": "OBP60 Page 4",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page4type":"TwoValues"},{"page4type":"ThreeValues"},{"page4type":"FourValues"},{"page4type":"FourValues2"},{"page4type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page4type": "FourValues"
+            },
+            {
+                "page4type": "FourValues2"
+            },
+            {
+                "page4type": "RollPitch"
+            },
+            {
+                "page4type": "ThreeValues"
+            },
+            {
+                "page4type": "TwoValues"
+            },
+            {
+                "page4type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page4value3",
         "label": "Field 3",
         "type": "boatData",
         "default": "",
-        "description": "The display for field 3",
+        "description": "The display for field three",
         "category": "OBP60 Page 4",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page4type":"ThreeValues"},{"page4type":"FourValues"},{"page4type":"FourValues2"},{"page4type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page4type": "FourValues"
+            },
+            {
+                "page4type": "FourValues2"
+            },
+            {
+                "page4type": "ThreeValues"
+            },
+            {
+                "page4type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page4value4",
         "label": "Field 4",
         "type": "boatData",
         "default": "",
-        "description": "The display for field 4",
+        "description": "The display for field four",
         "category": "OBP60 Page 4",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page4type":"FourValues"},{"page4type":"FourValues2"},{"page4type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page4type": "FourValues"
+            },
+            {
+                "page4type": "FourValues2"
+            },
+            {
+                "page4type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page4value5",
         "label": "Field 5",
         "type": "boatData",
         "default": "",
-        "description": "The display for field 5",
+        "description": "The display for field five",
         "category": "OBP60 Page 4",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page4type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page4type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page4value6",
         "label": "Field 6",
         "type": "boatData",
         "default": "",
-        "description": "The display for field 6",
+        "description": "The display for field six",
         "category": "OBP60 Page 4",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page4type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page4type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page4fluid",
@@ -1322,20 +1884,45 @@
         "type": "list",
         "default": "0",
         "list": [
-            {"l":"Fuel (0)","v":"0"},
-            {"l":"Water (1)","v":"1"},
-            {"l":"Gray Water (2)","v":"2"},
-            {"l":"Live Well (3)","v":"3"},
-            {"l":"Oil (4)","v":"4"},
-            {"l":"Black Water (5)","v":"5"},
-            {"l":"Fuel Gasoline (6)","v":"6"}
+            {
+                "l": "Fuel (0)",
+                "v": "0"
+            },
+            {
+                "l": "Water (1)",
+                "v": "1"
+            },
+            {
+                "l": "Gray Water (2)",
+                "v": "2"
+            },
+            {
+                "l": "Live Well (3)",
+                "v": "3"
+            },
+            {
+                "l": "Oil (4)",
+                "v": "4"
+            },
+            {
+                "l": "Black Water (5)",
+                "v": "5"
+            },
+            {
+                "l": "Fuel Gasoline (6)",
+                "v": "6"
+            }
         ],
         "description": "Fluid type in tank",
         "category": "OBP60 Page 4",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page4type":"Fluid"}]
+        "condition": [
+            {
+                "page4type": "Fluid"
+            }
+        ]
     },
     {
         "name": "page5type",
@@ -1343,84 +1930,198 @@
         "type": "list",
         "default": "ThreeValues",
         "description": "Type of page for page 5",
-        "list":["OneValue","TwoValues","ThreeValues","FourValues","FourValues2","ApparentWind","WindRose","WindRoseFlex","Voltage","DST810","Clock","WhitePage","BME280","RudderPosition","KeelPosition","Battery","Battery2","RollPitch","Solar","Generator","XTETrack","Fluid"],
+        "list": [
+            "ApparentWind",
+            "BME280",
+            "Battery",
+            "Battery2",
+            "Clock",
+            "DST810",
+            "Fluid",
+            "FourValues",
+            "FourValues2",
+            "Generator",
+            "KeelPosition",
+            "OneValue",
+            "RollPitch",
+            "RudderPosition",
+            "Solar",
+            "ThreeValues",
+            "TwoValues",
+            "Voltage",
+            "White",
+            "WindRose",
+            "WindRoseFlex",
+            "XTETrack"
+        ],
         "category": "OBP60 Page 5",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"visiblePages":"5"},{"visiblePages":"6"},{"visiblePages":"7"},{"visiblePages":"8"},{"visiblePages":"9"},{"visiblePages":"10"}]
+        "condition": [
+            {
+                "visiblePages": 5
+            },
+            {
+                "visiblePages": 6
+            },
+            {
+                "visiblePages": 7
+            },
+            {
+                "visiblePages": 8
+            },
+            {
+                "visiblePages": 9
+            },
+            {
+                "visiblePages": 10
+            }
+        ]
     },
     {
         "name": "page5value1",
         "label": "Field 1",
         "type": "boatData",
-        "default": "COG",
+        "default": "",
         "description": "The display for field one",
         "category": "OBP60 Page 5",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page5type":"OneValue"},{"page5type":"TwoValues"},{"page5type":"ThreeValues"},{"page5type":"FourValues"},{"page5type":"FourValues2"},{"page4type":"WindRoseFlex"},{"page5type":"Fluid"}]
+        "condition": [
+            {
+                "page5type": "FourValues"
+            },
+            {
+                "page5type": "FourValues2"
+            },
+            {
+                "page5type": "OneValue"
+            },
+            {
+                "page5type": "RollPitch"
+            },
+            {
+                "page5type": "ThreeValues"
+            },
+            {
+                "page5type": "TwoValues"
+            },
+            {
+                "page5type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page5value2",
         "label": "Field 2",
         "type": "boatData",
-        "default": "STW",
+        "default": "",
         "description": "The display for field two",
         "category": "OBP60 Page 5",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page5type":"TwoValues"},{"page5type":"ThreeValues"},{"page5type":"FourValues"},{"page5type":"FourValues2"},{"page4type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page5type": "FourValues"
+            },
+            {
+                "page5type": "FourValues2"
+            },
+            {
+                "page5type": "RollPitch"
+            },
+            {
+                "page5type": "ThreeValues"
+            },
+            {
+                "page5type": "TwoValues"
+            },
+            {
+                "page5type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page5value3",
         "label": "Field 3",
         "type": "boatData",
-        "default": "DBT",
-        "description": "The display for field 3",
+        "default": "",
+        "description": "The display for field three",
         "category": "OBP60 Page 5",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page5type":"ThreeValues"},{"page5type":"FourValues"},{"page5type":"FourValues2"},{"page5type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page5type": "FourValues"
+            },
+            {
+                "page5type": "FourValues2"
+            },
+            {
+                "page5type": "ThreeValues"
+            },
+            {
+                "page5type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page5value4",
         "label": "Field 4",
         "type": "boatData",
         "default": "",
-        "description": "The display for field 4",
+        "description": "The display for field four",
         "category": "OBP60 Page 5",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page5type":"FourValues"},{"page5type":"FourValues2"},{"page5type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page5type": "FourValues"
+            },
+            {
+                "page5type": "FourValues2"
+            },
+            {
+                "page5type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page5value5",
         "label": "Field 5",
         "type": "boatData",
         "default": "",
-        "description": "The display for field 5",
+        "description": "The display for field five",
         "category": "OBP60 Page 5",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page5type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page5type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page5value6",
         "label": "Field 6",
         "type": "boatData",
         "default": "",
-        "description": "The display for field 6",
+        "description": "The display for field six",
         "category": "OBP60 Page 5",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page5type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page5type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page5fluid",
@@ -1428,20 +2129,45 @@
         "type": "list",
         "default": "0",
         "list": [
-            {"l":"Fuel (0)","v":"0"},
-            {"l":"Water (1)","v":"1"},
-            {"l":"Gray Water (2)","v":"2"},
-            {"l":"Live Well (3)","v":"3"},
-            {"l":"Oil (4)","v":"4"},
-            {"l":"Black Water (5)","v":"5"},
-            {"l":"Fuel Gasoline (6)","v":"6"}
+            {
+                "l": "Fuel (0)",
+                "v": "0"
+            },
+            {
+                "l": "Water (1)",
+                "v": "1"
+            },
+            {
+                "l": "Gray Water (2)",
+                "v": "2"
+            },
+            {
+                "l": "Live Well (3)",
+                "v": "3"
+            },
+            {
+                "l": "Oil (4)",
+                "v": "4"
+            },
+            {
+                "l": "Black Water (5)",
+                "v": "5"
+            },
+            {
+                "l": "Fuel Gasoline (6)",
+                "v": "6"
+            }
         ],
         "description": "Fluid type in tank",
         "category": "OBP60 Page 5",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page5type":"Fluid"}]
+        "condition": [
+            {
+                "page5type": "Fluid"
+            }
+        ]
     },
     {
         "name": "page6type",
@@ -1449,84 +2175,195 @@
         "type": "list",
         "default": "FourValues",
         "description": "Type of page for page 6",
-        "list":["OneValue","TwoValues","ThreeValues","FourValues","FourValues2","ApparentWind","WindRose","WindRoseFlex","Voltage","DST810","Clock","WhitePage","BME280","RudderPosition","KeelPosition","Battery","Battery2","RollPitch","Solar","Generator","XTETrack","Fluid"],
+        "list": [
+            "ApparentWind",
+            "BME280",
+            "Battery",
+            "Battery2",
+            "Clock",
+            "DST810",
+            "Fluid",
+            "FourValues",
+            "FourValues2",
+            "Generator",
+            "KeelPosition",
+            "OneValue",
+            "RollPitch",
+            "RudderPosition",
+            "Solar",
+            "ThreeValues",
+            "TwoValues",
+            "Voltage",
+            "White",
+            "WindRose",
+            "WindRoseFlex",
+            "XTETrack"
+        ],
         "category": "OBP60 Page 6",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"visiblePages":"6"},{"visiblePages":"7"},{"visiblePages":"8"},{"visiblePages":"9"},{"visiblePages":"10"}]
+        "condition": [
+            {
+                "visiblePages": 6
+            },
+            {
+                "visiblePages": 7
+            },
+            {
+                "visiblePages": 8
+            },
+            {
+                "visiblePages": 9
+            },
+            {
+                "visiblePages": 10
+            }
+        ]
     },
     {
         "name": "page6value1",
         "label": "Field 1",
         "type": "boatData",
-        "default": "AWA",
+        "default": "",
         "description": "The display for field one",
         "category": "OBP60 Page 6",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page6type":"OneValue"},{"page6type":"TwoValues"},{"page6type":"ThreeValues"},{"page6type":"FourValues"},{"page6type":"FourValues2"},{"page6type":"WindRoseFlex"},{"page6type":"Fluid"}]
+        "condition": [
+            {
+                "page6type": "FourValues"
+            },
+            {
+                "page6type": "FourValues2"
+            },
+            {
+                "page6type": "OneValue"
+            },
+            {
+                "page6type": "RollPitch"
+            },
+            {
+                "page6type": "ThreeValues"
+            },
+            {
+                "page6type": "TwoValues"
+            },
+            {
+                "page6type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page6value2",
         "label": "Field 2",
         "type": "boatData",
-        "default": "AWS",
+        "default": "",
         "description": "The display for field two",
         "category": "OBP60 Page 6",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page6type":"TwoValues"},{"page6type":"ThreeValues"},{"page6type":"FourValues"},{"page6type":"FourValues2"},{"page6type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page6type": "FourValues"
+            },
+            {
+                "page6type": "FourValues2"
+            },
+            {
+                "page6type": "RollPitch"
+            },
+            {
+                "page6type": "ThreeValues"
+            },
+            {
+                "page6type": "TwoValues"
+            },
+            {
+                "page6type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page6value3",
         "label": "Field 3",
         "type": "boatData",
-        "default": "COG",
-        "description": "The display for field 3",
+        "default": "",
+        "description": "The display for field three",
         "category": "OBP60 Page 6",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page6type":"ThreeValues"},{"page6type":"FourValues"},{"page6type":"FourValues2"},{"page6type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page6type": "FourValues"
+            },
+            {
+                "page6type": "FourValues2"
+            },
+            {
+                "page6type": "ThreeValues"
+            },
+            {
+                "page6type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page6value4",
         "label": "Field 4",
         "type": "boatData",
-        "default": "STW",
-        "description": "The display for field 4",
+        "default": "",
+        "description": "The display for field four",
         "category": "OBP60 Page 6",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page6type":"FourValues"},{"page6type":"FourValues2"},{"page6type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page6type": "FourValues"
+            },
+            {
+                "page6type": "FourValues2"
+            },
+            {
+                "page6type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page6value5",
         "label": "Field 5",
         "type": "boatData",
         "default": "",
-        "description": "The display for field 5",
+        "description": "The display for field five",
         "category": "OBP60 Page 6",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page6type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page6type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page6value6",
         "label": "Field 6",
         "type": "boatData",
         "default": "",
-        "description": "The display for field 6",
+        "description": "The display for field six",
         "category": "OBP60 Page 6",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page6type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page6type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page6fluid",
@@ -1534,20 +2371,45 @@
         "type": "list",
         "default": "0",
         "list": [
-            {"l":"Fuel (0)","v":"0"},
-            {"l":"Water (1)","v":"1"},
-            {"l":"Gray Water (2)","v":"2"},
-            {"l":"Live Well (3)","v":"3"},
-            {"l":"Oil (4)","v":"4"},
-            {"l":"Black Water (5)","v":"5"},
-            {"l":"Fuel Gasoline (6)","v":"6"}
+            {
+                "l": "Fuel (0)",
+                "v": "0"
+            },
+            {
+                "l": "Water (1)",
+                "v": "1"
+            },
+            {
+                "l": "Gray Water (2)",
+                "v": "2"
+            },
+            {
+                "l": "Live Well (3)",
+                "v": "3"
+            },
+            {
+                "l": "Oil (4)",
+                "v": "4"
+            },
+            {
+                "l": "Black Water (5)",
+                "v": "5"
+            },
+            {
+                "l": "Fuel Gasoline (6)",
+                "v": "6"
+            }
         ],
         "description": "Fluid type in tank",
         "category": "OBP60 Page 6",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page6type":"Fluid"}]
+        "condition": [
+            {
+                "page6type": "Fluid"
+            }
+        ]
     },
     {
         "name": "page7type",
@@ -1555,84 +2417,192 @@
         "type": "list",
         "default": "FourValues2",
         "description": "Type of page for page 7",
-        "list":["OneValue","TwoValues","ThreeValues","FourValues","FourValues2","ApparentWind","WindRose","WindRoseFlex","Voltage","DST810","Clock","WhitePage","BME280","RudderPosition","KeelPosition","Battery","Battery2","RollPitch","Solar","Generator","XTETrack","Fluid"],
+        "list": [
+            "ApparentWind",
+            "BME280",
+            "Battery",
+            "Battery2",
+            "Clock",
+            "DST810",
+            "Fluid",
+            "FourValues",
+            "FourValues2",
+            "Generator",
+            "KeelPosition",
+            "OneValue",
+            "RollPitch",
+            "RudderPosition",
+            "Solar",
+            "ThreeValues",
+            "TwoValues",
+            "Voltage",
+            "White",
+            "WindRose",
+            "WindRoseFlex",
+            "XTETrack"
+        ],
         "category": "OBP60 Page 7",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"visiblePages":"7"},{"visiblePages":"8"},{"visiblePages":"9"},{"visiblePages":"10"}]
+        "condition": [
+            {
+                "visiblePages": 7
+            },
+            {
+                "visiblePages": 8
+            },
+            {
+                "visiblePages": 9
+            },
+            {
+                "visiblePages": 10
+            }
+        ]
     },
     {
         "name": "page7value1",
         "label": "Field 1",
         "type": "boatData",
-        "default": "AWA",
+        "default": "",
         "description": "The display for field one",
         "category": "OBP60 Page 7",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page7type":"OneValue"},{"page7type":"TwoValues"},{"page7type":"ThreeValues"},{"page7type":"FourValues"},{"page7type":"FourValues2"},{"page7type":"WindRoseFlex"},{"page7type":"Fluid"}]
+        "condition": [
+            {
+                "page7type": "FourValues"
+            },
+            {
+                "page7type": "FourValues2"
+            },
+            {
+                "page7type": "OneValue"
+            },
+            {
+                "page7type": "RollPitch"
+            },
+            {
+                "page7type": "ThreeValues"
+            },
+            {
+                "page7type": "TwoValues"
+            },
+            {
+                "page7type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page7value2",
         "label": "Field 2",
         "type": "boatData",
-        "default": "AWS",
+        "default": "",
         "description": "The display for field two",
         "category": "OBP60 Page 7",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page7type":"TwoValues"},{"page7type":"ThreeValues"},{"page7type":"FourValues"},{"page7type":"FourValues2"},{"page7type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page7type": "FourValues"
+            },
+            {
+                "page7type": "FourValues2"
+            },
+            {
+                "page7type": "RollPitch"
+            },
+            {
+                "page7type": "ThreeValues"
+            },
+            {
+                "page7type": "TwoValues"
+            },
+            {
+                "page7type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page7value3",
         "label": "Field 3",
         "type": "boatData",
-        "default": "COG",
-        "description": "The display for field 3",
+        "default": "",
+        "description": "The display for field three",
         "category": "OBP60 Page 7",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page7type":"ThreeValues"},{"page7type":"FourValues"},{"page7type":"FourValues2"},{"page7type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page7type": "FourValues"
+            },
+            {
+                "page7type": "FourValues2"
+            },
+            {
+                "page7type": "ThreeValues"
+            },
+            {
+                "page7type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page7value4",
         "label": "Field 4",
         "type": "boatData",
-        "default": "STW",
-        "description": "The display for field 4",
+        "default": "",
+        "description": "The display for field four",
         "category": "OBP60 Page 7",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page7type":"FourValues"},{"page7type":"FourValues2"},{"page7type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page7type": "FourValues"
+            },
+            {
+                "page7type": "FourValues2"
+            },
+            {
+                "page7type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page7value5",
         "label": "Field 5",
         "type": "boatData",
         "default": "",
-        "description": "The display for field 5",
+        "description": "The display for field five",
         "category": "OBP60 Page 7",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page7type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page7type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page7value6",
         "label": "Field 6",
         "type": "boatData",
         "default": "",
-        "description": "The display for field 6",
+        "description": "The display for field six",
         "category": "OBP60 Page 7",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page7type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page7type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page7fluid",
@@ -1640,20 +2610,45 @@
         "type": "list",
         "default": "0",
         "list": [
-            {"l":"Fuel (0)","v":"0"},
-            {"l":"Water (1)","v":"1"},
-            {"l":"Gray Water (2)","v":"2"},
-            {"l":"Live Well (3)","v":"3"},
-            {"l":"Oil (4)","v":"4"},
-            {"l":"Black Water (5)","v":"5"},
-            {"l":"Fuel Gasoline (6)","v":"6"}
+            {
+                "l": "Fuel (0)",
+                "v": "0"
+            },
+            {
+                "l": "Water (1)",
+                "v": "1"
+            },
+            {
+                "l": "Gray Water (2)",
+                "v": "2"
+            },
+            {
+                "l": "Live Well (3)",
+                "v": "3"
+            },
+            {
+                "l": "Oil (4)",
+                "v": "4"
+            },
+            {
+                "l": "Black Water (5)",
+                "v": "5"
+            },
+            {
+                "l": "Fuel Gasoline (6)",
+                "v": "6"
+            }
         ],
         "description": "Fluid type in tank",
         "category": "OBP60 Page 7",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page7type":"Fluid"}]
+        "condition": [
+            {
+                "page7type": "Fluid"
+            }
+        ]
     },
     {
         "name": "page8type",
@@ -1661,24 +2656,79 @@
         "type": "list",
         "default": "Clock",
         "description": "Type of page for page 8",
-        "list":["OneValue","TwoValues","ThreeValues","FourValues","FourValues2","ApparentWind","WindRose","WindRoseFlex","Voltage","DST810","Clock","WhitePage","BME280","RudderPosition","KeelPosition","Battery","Battery2","RollPitch","Solar","Generator","XTETrack","Fluid"],
+        "list": [
+            "ApparentWind",
+            "BME280",
+            "Battery",
+            "Battery2",
+            "Clock",
+            "DST810",
+            "Fluid",
+            "FourValues",
+            "FourValues2",
+            "Generator",
+            "KeelPosition",
+            "OneValue",
+            "RollPitch",
+            "RudderPosition",
+            "Solar",
+            "ThreeValues",
+            "TwoValues",
+            "Voltage",
+            "White",
+            "WindRose",
+            "WindRoseFlex",
+            "XTETrack"
+        ],
         "category": "OBP60 Page 8",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"visiblePages":"8"},{"visiblePages":"9"},{"visiblePages":"10"}]
+        "condition": [
+            {
+                "visiblePages": 8
+            },
+            {
+                "visiblePages": 9
+            },
+            {
+                "visiblePages": 10
+            }
+        ]
     },
     {
         "name": "page8value1",
         "label": "Field 1",
         "type": "boatData",
-        "default": "AWS",
+        "default": "",
         "description": "The display for field one",
         "category": "OBP60 Page 8",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page8type":"OneValue"},{"page8type":"TwoValues"},{"page8type":"ThreeValues"},{"page8type":"FourValues"},{"page8type":"FourValues2"},{"page8type":"WindRoseFlex"},{"page8type":"Fluid"}]
+        "condition": [
+            {
+                "page8type": "FourValues"
+            },
+            {
+                "page8type": "FourValues2"
+            },
+            {
+                "page8type": "OneValue"
+            },
+            {
+                "page8type": "RollPitch"
+            },
+            {
+                "page8type": "ThreeValues"
+            },
+            {
+                "page8type": "TwoValues"
+            },
+            {
+                "page8type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page8value2",
@@ -1688,57 +2738,107 @@
         "description": "The display for field two",
         "category": "OBP60 Page 8",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page8type":"TwoValues"},{"page8type":"ThreeValues"},{"page8type":"FourValues"},{"page8type":"FourValues2"},{"page8type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page8type": "FourValues"
+            },
+            {
+                "page8type": "FourValues2"
+            },
+            {
+                "page8type": "RollPitch"
+            },
+            {
+                "page8type": "ThreeValues"
+            },
+            {
+                "page8type": "TwoValues"
+            },
+            {
+                "page8type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page8value3",
         "label": "Field 3",
         "type": "boatData",
         "default": "",
-        "description": "The display for field 3",
+        "description": "The display for field three",
         "category": "OBP60 Page 8",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page8type":"ThreeValues"},{"page8type":"FourValues"},{"page8type":"FourValues2"},{"page8type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page8type": "FourValues"
+            },
+            {
+                "page8type": "FourValues2"
+            },
+            {
+                "page8type": "ThreeValues"
+            },
+            {
+                "page8type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page8value4",
         "label": "Field 4",
         "type": "boatData",
         "default": "",
-        "description": "The display for field 4",
+        "description": "The display for field four",
         "category": "OBP60 Page 8",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page8type":"FourValues"},{"page8type":"FourValues2"},{"page88type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page8type": "FourValues"
+            },
+            {
+                "page8type": "FourValues2"
+            },
+            {
+                "page8type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page8value5",
         "label": "Field 5",
         "type": "boatData",
         "default": "",
-        "description": "The display for field 5",
+        "description": "The display for field five",
         "category": "OBP60 Page 8",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page8type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page8type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page8value6",
         "label": "Field 6",
         "type": "boatData",
         "default": "",
-        "description": "The display for field 6",
+        "description": "The display for field six",
         "category": "OBP60 Page 8",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page8type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page8type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page8fluid",
@@ -1746,20 +2846,45 @@
         "type": "list",
         "default": "0",
         "list": [
-            {"l":"Fuel (0)","v":"0"},
-            {"l":"Water (1)","v":"1"},
-            {"l":"Gray Water (2)","v":"2"},
-            {"l":"Live Well (3)","v":"3"},
-            {"l":"Oil (4)","v":"4"},
-            {"l":"Black Water (5)","v":"5"},
-            {"l":"Fuel Gasoline (6)","v":"6"}
+            {
+                "l": "Fuel (0)",
+                "v": "0"
+            },
+            {
+                "l": "Water (1)",
+                "v": "1"
+            },
+            {
+                "l": "Gray Water (2)",
+                "v": "2"
+            },
+            {
+                "l": "Live Well (3)",
+                "v": "3"
+            },
+            {
+                "l": "Oil (4)",
+                "v": "4"
+            },
+            {
+                "l": "Black Water (5)",
+                "v": "5"
+            },
+            {
+                "l": "Fuel Gasoline (6)",
+                "v": "6"
+            }
         ],
         "description": "Fluid type in tank",
         "category": "OBP60 Page 8",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page8type":"Fluid"}]
+        "condition": [
+            {
+                "page8type": "Fluid"
+            }
+        ]
     },
     {
         "name": "page9type",
@@ -1767,24 +2892,76 @@
         "type": "list",
         "default": "RollPitch",
         "description": "Type of page for page 9",
-        "list":["OneValue","TwoValues","ThreeValues","FourValues","FourValues2","ApparentWind","WindRose","WindRoseFlex","Voltage","DST810","Clock","WhitePage","BME280","RudderPosition","KeelPosition","Battery","Battery2","RollPitch","Solar","Generator","XTETrack","Fluid"],
+        "list": [
+            "ApparentWind",
+            "BME280",
+            "Battery",
+            "Battery2",
+            "Clock",
+            "DST810",
+            "Fluid",
+            "FourValues",
+            "FourValues2",
+            "Generator",
+            "KeelPosition",
+            "OneValue",
+            "RollPitch",
+            "RudderPosition",
+            "Solar",
+            "ThreeValues",
+            "TwoValues",
+            "Voltage",
+            "White",
+            "WindRose",
+            "WindRoseFlex",
+            "XTETrack"
+        ],
         "category": "OBP60 Page 9",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"visiblePages":"9"},{"visiblePages":"10"}]
+        "condition": [
+            {
+                "visiblePages": 9
+            },
+            {
+                "visiblePages": 10
+            }
+        ]
     },
     {
         "name": "page9value1",
         "label": "Field 1",
         "type": "boatData",
-        "default": "AWS",
+        "default": "",
         "description": "The display for field one",
         "category": "OBP60 Page 9",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page9type":"OneValue"},{"page9type":"TwoValues"},{"page9type":"ThreeValues"},{"page9type":"FourValues"},{"page9type":"FourValues2"},{"page9type":"WindRoseFlex"},{"page9type":"Fluid"}]
+        "condition": [
+            {
+                "page9type": "FourValues"
+            },
+            {
+                "page9type": "FourValues2"
+            },
+            {
+                "page9type": "OneValue"
+            },
+            {
+                "page9type": "RollPitch"
+            },
+            {
+                "page9type": "ThreeValues"
+            },
+            {
+                "page9type": "TwoValues"
+            },
+            {
+                "page9type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page9value2",
@@ -1794,57 +2971,107 @@
         "description": "The display for field two",
         "category": "OBP60 Page 9",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page9type":"TwoValues"},{"page9type":"ThreeValues"},{"page9type":"FourValues"},{"page9type":"FourValues2"},{"page9type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page9type": "FourValues"
+            },
+            {
+                "page9type": "FourValues2"
+            },
+            {
+                "page9type": "RollPitch"
+            },
+            {
+                "page9type": "ThreeValues"
+            },
+            {
+                "page9type": "TwoValues"
+            },
+            {
+                "page9type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page9value3",
         "label": "Field 3",
         "type": "boatData",
         "default": "",
-        "description": "The display for field 3",
+        "description": "The display for field three",
         "category": "OBP60 Page 9",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page9type":"ThreeValues"},{"page9type":"FourValues"},{"page9type":"FourValues2"},{"page9type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page9type": "FourValues"
+            },
+            {
+                "page9type": "FourValues2"
+            },
+            {
+                "page9type": "ThreeValues"
+            },
+            {
+                "page9type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page9value4",
         "label": "Field 4",
         "type": "boatData",
         "default": "",
-        "description": "The display for field 4",
+        "description": "The display for field four",
         "category": "OBP60 Page 9",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page9type":"FourValues"},{"page9type":"FourValues2"},{"page9type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page9type": "FourValues"
+            },
+            {
+                "page9type": "FourValues2"
+            },
+            {
+                "page9type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page9value5",
         "label": "Field 5",
         "type": "boatData",
         "default": "",
-        "description": "The display for field 5",
+        "description": "The display for field five",
         "category": "OBP60 Page 9",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page9type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page9type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page9value6",
         "label": "Field 6",
         "type": "boatData",
         "default": "",
-        "description": "The display for field 6",
+        "description": "The display for field six",
         "category": "OBP60 Page 9",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page9type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page9type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page9fluid",
@@ -1852,20 +3079,45 @@
         "type": "list",
         "default": "0",
         "list": [
-            {"l":"Fuel (0)","v":"0"},
-            {"l":"Water (1)","v":"1"},
-            {"l":"Gray Water (2)","v":"2"},
-            {"l":"Live Well (3)","v":"3"},
-            {"l":"Oil (4)","v":"4"},
-            {"l":"Black Water (5)","v":"5"},
-            {"l":"Fuel Gasoline (6)","v":"6"}
+            {
+                "l": "Fuel (0)",
+                "v": "0"
+            },
+            {
+                "l": "Water (1)",
+                "v": "1"
+            },
+            {
+                "l": "Gray Water (2)",
+                "v": "2"
+            },
+            {
+                "l": "Live Well (3)",
+                "v": "3"
+            },
+            {
+                "l": "Oil (4)",
+                "v": "4"
+            },
+            {
+                "l": "Black Water (5)",
+                "v": "5"
+            },
+            {
+                "l": "Fuel Gasoline (6)",
+                "v": "6"
+            }
         ],
         "description": "Fluid type in tank",
         "category": "OBP60 Page 9",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page9type":"Fluid"}]
+        "condition": [
+            {
+                "page9type": "Fluid"
+            }
+        ]
     },
     {
         "name": "page10type",
@@ -1873,24 +3125,73 @@
         "type": "list",
         "default": "Battery2",
         "description": "Type of page for page 10",
-        "list":["OneValue","TwoValues","ThreeValues","FourValues","FourValues2","ApparentWind","WindRose","WindRoseFlex","Voltage","DST810","Clock","WhitePage","BME280","RudderPosition","KeelPosition","Battery","Battery2","RollPitch","Solar","Generator","XTETrack","Fluid"],
+        "list": [
+            "ApparentWind",
+            "BME280",
+            "Battery",
+            "Battery2",
+            "Clock",
+            "DST810",
+            "Fluid",
+            "FourValues",
+            "FourValues2",
+            "Generator",
+            "KeelPosition",
+            "OneValue",
+            "RollPitch",
+            "RudderPosition",
+            "Solar",
+            "ThreeValues",
+            "TwoValues",
+            "Voltage",
+            "White",
+            "WindRose",
+            "WindRoseFlex",
+            "XTETrack"
+        ],
         "category": "OBP60 Page 10",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"visiblePages":"10"}]
+        "condition": [
+            {
+                "visiblePages": 10
+            }
+        ]
     },
     {
         "name": "page10value1",
         "label": "Field 1",
         "type": "boatData",
-        "default": "AWS",
+        "default": "",
         "description": "The display for field one",
         "category": "OBP60 Page 10",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page10type":"OneValue"},{"page10type":"TwoValues"},{"page10type":"ThreeValues"},{"page10type":"FourValues"},{"page10type":"FourValues2"},{"page10type":"WindRoseFlex"},{"page10type":"Fluid"}]
+        "condition": [
+            {
+                "page10type": "FourValues"
+            },
+            {
+                "page10type": "FourValues2"
+            },
+            {
+                "page10type": "OneValue"
+            },
+            {
+                "page10type": "RollPitch"
+            },
+            {
+                "page10type": "ThreeValues"
+            },
+            {
+                "page10type": "TwoValues"
+            },
+            {
+                "page10type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page10value2",
@@ -1900,57 +3201,107 @@
         "description": "The display for field two",
         "category": "OBP60 Page 10",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page10type":"TwoValues"},{"page10type":"ThreeValues"},{"page10type":"FourValues"},{"page10type":"FourValues2"},{"page10type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page10type": "FourValues"
+            },
+            {
+                "page10type": "FourValues2"
+            },
+            {
+                "page10type": "RollPitch"
+            },
+            {
+                "page10type": "ThreeValues"
+            },
+            {
+                "page10type": "TwoValues"
+            },
+            {
+                "page10type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page10value3",
         "label": "Field 3",
         "type": "boatData",
         "default": "",
-        "description": "The display for field 3",
+        "description": "The display for field three",
         "category": "OBP60 Page 10",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page10type":"ThreeValues"},{"page10type":"FourValues"},{"page10type":"FourValues2"},{"page10type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page10type": "FourValues"
+            },
+            {
+                "page10type": "FourValues2"
+            },
+            {
+                "page10type": "ThreeValues"
+            },
+            {
+                "page10type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page10value4",
         "label": "Field 4",
         "type": "boatData",
         "default": "",
-        "description": "The display for field 4",
+        "description": "The display for field four",
         "category": "OBP60 Page 10",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page10type":"FourValues"},{"page10type":"FourValues2"},{"page10type":"WindRoseFlex"}]
-    },   
+        "condition": [
+            {
+                "page10type": "FourValues"
+            },
+            {
+                "page10type": "FourValues2"
+            },
+            {
+                "page10type": "WindRoseFlex"
+            }
+        ]
+    },
     {
         "name": "page10value5",
         "label": "Field 5",
         "type": "boatData",
         "default": "",
-        "description": "The display for field 5",
+        "description": "The display for field five",
         "category": "OBP60 Page 10",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page10type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page10type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page10value6",
         "label": "Field 6",
         "type": "boatData",
         "default": "",
-        "description": "The display for field 6",
+        "description": "The display for field six",
         "category": "OBP60 Page 10",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page10type":"WindRoseFlex"}]
+        "condition": [
+            {
+                "page10type": "WindRoseFlex"
+            }
+        ]
     },
     {
         "name": "page10fluid",
@@ -1958,19 +3309,45 @@
         "type": "list",
         "default": "0",
         "list": [
-            {"l":"Fuel (0)","v":"0"},
-            {"l":"Water (1)","v":"1"},
-            {"l":"Gray Water (2)","v":"2"},
-            {"l":"Live Well (3)","v":"3"},
-            {"l":"Oil (4)","v":"4"},
-            {"l":"Black Water (5)","v":"5"},
-            {"l":"Fuel Gasoline (6)","v":"6"}
+            {
+                "l": "Fuel (0)",
+                "v": "0"
+            },
+            {
+                "l": "Water (1)",
+                "v": "1"
+            },
+            {
+                "l": "Gray Water (2)",
+                "v": "2"
+            },
+            {
+                "l": "Live Well (3)",
+                "v": "3"
+            },
+            {
+                "l": "Oil (4)",
+                "v": "4"
+            },
+            {
+                "l": "Black Water (5)",
+                "v": "5"
+            },
+            {
+                "l": "Fuel Gasoline (6)",
+                "v": "6"
+            }
         ],
         "description": "Fluid type in tank",
         "category": "OBP60 Page 10",
         "capabilities": {
-            "obp60":"true"
+            "obp60": "true"
         },
-        "condition":[{"page10type":"Fluid"}]
+        "condition": [
+            {
+                "page10type": "Fluid"
+            }
+        ]
     }
 ]
+

--- a/lib/obp60task/gen_set.pl
+++ b/lib/obp60task/gen_set.pl
@@ -1,6 +1,7 @@
 #!/bin/perl -w
 #A tool to generate the part of config.json that deals with pages and fields.
-
+#DEPRECATED, moved to get_set.py
+die "Please use gen_set.py instead";
 #List of all pages and the number of parameters they expect.
 %NoOfFieldsPerPage=qw( 
                 ApparentWind    0
@@ -81,7 +82,7 @@ for ($PageNo=1;$PageNo<=$NoOfPages;$PageNo++){
         print "\t",'"condition":[';
         foreach $page (@Pages) {
             if($NoOfFieldsPerPage{$page}>=$FieldNo){ 
-                print '{"page1type":"',$page,'"},';
+                print '{"page',$PageNo,'type":"',$page,'"},';
             } 
         } 
         print "\b],\n";

--- a/lib/obp60task/gen_set.py
+++ b/lib/obp60task/gen_set.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# A tool to generate that part of config.json  that deals with pages and fields.
+
+import json
+
+# List of all pages and the number of parameters they expect.
+no_of_fields_per_page = {
+    "ApparentWind": 0,
+    "XTETrack": 0,
+    "Battery2": 0,
+    "Battery": 0,
+    "BME280": 0,
+    "Clock": 0,
+    "DST810": 0,
+    "Fluid": 0,
+    "FourValues2": 4,
+    "FourValues": 4,
+    "Generator": 0,
+    "KeelPosition": 0,
+    "OneValue": 1,
+    "RollPitch": 2,
+    "RudderPosition": 0,
+    "Solar": 0,
+    "ThreeValues": 3,
+    "TwoValues": 2,
+    "Voltage": 0,
+    "White": 0,
+    "WindRose": 0,
+    "WindRoseFlex": 6,
+}
+
+# No changes needed beyond this point
+# max number of pages supported by OBP60
+no_of_pages = 10
+# Default selection for each page
+default_pages = [
+    "Voltage",
+    "WindRose",
+    "OneValue",
+    "TwoValues",
+    "ThreeValues",
+    "FourValues",
+    "FourValues2",
+    "Clock",
+    "RollPitch",
+    "Battery2",
+]
+numbers = [
+    "one",
+    "two",
+    "three",
+    "four",
+    "five",
+    "six",
+    "seven",
+    "eight",
+    "nine",
+    "ten",
+]
+pages = sorted(no_of_fields_per_page.keys())
+max_no_of_fields_per_page = max(no_of_fields_per_page.values())
+
+output = []
+
+for page_no in range(1, no_of_pages + 1):
+    page_data = {
+        "name": f"page{page_no}type",
+        "label": "Type",
+        "type": "list",
+        "default": default_pages[page_no - 1],
+        "description": f"Type of page for page {page_no}",
+        "list": pages,
+        "category": f"OBP60 Page {page_no}",
+        "capabilities": {"obp60": "true"},
+        "condition": [{"visiblePages": vp} for vp in range(page_no, no_of_pages + 1)],
+        #"fields": [],
+    }
+    output.append(page_data)
+
+    for field_no in range(1, max_no_of_fields_per_page + 1):
+        field_data = {
+            "name": f"page{page_no}value{field_no}",
+            "label": f"Field {field_no}",
+            "type": "boatData",
+            "default": "",
+            "description": f"The display for field {numbers[field_no - 1]}",
+            "category": f"OBP60 Page {page_no}",
+            "capabilities": {"obp60": "true"},
+            "condition": [
+                {f"page{page_no}type": page}
+                for page in pages
+                if no_of_fields_per_page[page] >= field_no
+            ],
+        }
+        output.append(field_data)
+
+    fluid_data ={
+        "name": f"page{page_no}fluid",
+        "label": "Fluid type",
+        "type": "list",
+        "default": "0",
+        "list": [
+        {"l":"Fuel (0)","v":"0"},
+        {"l":"Water (1)","v":"1"},
+        {"l":"Gray Water (2)","v":"2"},
+        {"l":"Live Well (3)","v":"3"},
+        {"l":"Oil (4)","v":"4"},
+        {"l":"Black Water (5)","v":"5"},
+        {"l":"Fuel Gasoline (6)","v":"6"}
+        ],
+        "description": "Fluid type in tank",
+        "category": f"OBP60 Page {page_no}",
+        "capabilities": {
+        "obp60":"true"
+        },
+        "condition":[{f"page{page_no}type":"Fluid"}]
+        } 
+    output.append(fluid_data)
+
+json_output = json.dumps(output, indent=4)
+# print omitting first and last line containing [ ] of JSON array
+print(json_output[1:-1])
+# print(",")


### PR DESCRIPTION
PageRollPitch now accepts 2 config options
Fixed conversion issue in PageWindRoseFlex
gen_set.pl is now obsolete, new version in python.
modified config.json (mostly reformatting due to gen_set.py), added 2 config fields for PageRollPitch

Fixes Issue #122  and #116 

