### PR TITLE
PageSixValues: compiler directive to include OPB40 support added

### DIFF
--- a/lib/obp60task/PageSixValues.cpp
+++ b/lib/obp60task/PageSixValues.cpp
@@ -1,4 +1,4 @@
-#if defined BOARD_OBP60S3 
+#if defined BOARD_OBP60S3 || defined BOARD_OBP40S3
 
 #include "Pagedata.h"
 #include "OBP60Extensions.h"


### PR DESCRIPTION
The change in platform.ini back to OBP40/60 support did not match the compiler directives at the beginning of PageSixValues:

#if defined BOARD_OBP60S3 || defined BOARD_OBP40S3
