### PR TITLE
Implement calibration of data types - request for comments

### DIFF
--- a/lib/obp60task/BoatDataCalibration.cpp
+++ b/lib/obp60task/BoatDataCalibration.cpp
@@ -48,6 +48,13 @@ void CalibrationDataList::readConfig(GwConfigHandler* config, GwLog* logger)
         } else if (calibrationData.list[i].instance == "AWA" || calibrationData.list[i].instance == "HDM") {
             calibrationData.list[i].offset *= M_PI / 180; // Convert deg to rad
 
+        } else if (calibrationData.list[i].instance == "DBT") {
+            if (lengthFormat == "m") {
+                // No conversion needed
+            } else if (lengthFormat == "ft") {
+                calibrationData.list[i].offset /= 3.28084; // Convert ft to m
+            }
+ 
         } else if (calibrationData.list[i].instance == "STW") {
             if (speedFormat == "m/s") {
                 // No conversion needed

--- a/lib/obp60task/BoatDataCalibration.cpp
+++ b/lib/obp60task/BoatDataCalibration.cpp
@@ -34,7 +34,7 @@ void CalibrationDataList::readConfig(GwConfigHandler* config, GwLog* logger)
         calibrationData.list[i].slope = (config->getString(slope, "")).toFloat();
 
         // Convert calibration values to internal standard formats
-        if (calibrationData.list[i].instance == "AWS") {
+        if (calibrationData.list[i].instance == "AWS" || calibrationData.list[i].instance == "TWS") {
             if (windspeedFormat == "m/s") {
                 // No conversion needed
             } else if (windspeedFormat == "km/h") {
@@ -45,7 +45,7 @@ void CalibrationDataList::readConfig(GwConfigHandler* config, GwLog* logger)
                 calibrationData.list[i].offset *= 0.5; // Convert Bft to m/s (approx) -> to be improved
             }
 
-        } else if (calibrationData.list[i].instance == "AWA" || calibrationData.list[i].instance == "HDM") {
+        } else if (calibrationData.list[i].instance == "AWA" || calibrationData.list[i].instance == "TWA" ||calibrationData.list[i].instance == "TWD" || calibrationData.list[i].instance == "HDM") {
             calibrationData.list[i].offset *= M_PI / 180; // Convert deg to rad
 
         } else if (calibrationData.list[i].instance == "DBT") {

--- a/lib/obp60task/BoatDataCalibration.cpp
+++ b/lib/obp60task/BoatDataCalibration.cpp
@@ -1,0 +1,123 @@
+#if defined BOARD_OBP60S3 || defined BOARD_OBP40S3
+
+#include "BoatDataCalibration.h"
+
+CalibrationDataList calibrationData;
+
+void CalibrationDataList::readConfig(GwConfigHandler* config, GwLog* logger)
+// Initial load of calibration data into internal list
+// This function is called once at init phase of <OBP60task> to read the configuration values
+{
+    // Load user configuration values
+    String lengthFormat = config->getString(config->lengthFormat); // [m|ft]
+    String distanceFormat = config->getString(config->distanceFormat); // [m|km|nm]
+    String speedFormat = config->getString(config->speedFormat); // [m/s|km/h|kn]
+    String windspeedFormat = config->getString(config->windspeedFormat); // [m/s|km/h|kn|bft]
+    String tempFormat = config->getString(config->tempFormat); // [K|°C|°F]
+
+    // Read calibration settings for DBT
+    calibrationData.list[0].instance = "DBT";
+    calibrationData.list[0].offset = (config->getString(config->calOffsetDBT)).toFloat();
+    if (lengthFormat == "ft") { // Convert DBT to SI standard meters
+        calibrationData.list[0].offset *= 0.3048;
+    }
+    calibrationData.list[0].slope = 1.0; // No slope for DBT
+    calibrationData.list[0].isCalibrated = false;
+
+    // Read calibration settings for other data instances
+    for (int i = 1; i < maxCalibrationData; i++) {
+        String instance = "calInstance" + String(i);
+        String offset = "calOffset" + String(i);
+        String slope = "calSlope" + String(i);
+
+//        calibrationData = new CalibrationDataList;
+        calibrationData.list[i].instance = config->getString(instance, "");
+        calibrationData.list[i].offset = (config->getString(offset, "")).toFloat();
+        calibrationData.list[i].slope = (config->getString(slope, "")).toFloat();
+        if (calibrationData.list[i].instance == "AWA" || calibrationData.list[i].instance == "AWS") {
+            if (windspeedFormat == "m/s") { // Convert calibration values to SI standard m/s
+                // No conversion needed
+            } else if (windspeedFormat == "km/h") {
+                calibrationData.list[i].offset /= 3.6; // Convert km/h to m/s
+                calibrationData.list[i].slope /= 3.6; // Convert km/h to m/s
+            } else if (windspeedFormat == "kn") {
+                calibrationData.list[i].offset /= 1.94384; // Convert kn to m/s
+                calibrationData.list[i].slope /= 1.94384; // Convert kn to m/s
+            } else if (windspeedFormat == "bft") {
+                calibrationData.list[i].offset *= 0.5; // Convert Bft to m/s (approx) -> to be improved
+                calibrationData.list[i].slope *= 0.5; // Convert km/h to m/s
+            }
+        } else if (calibrationData.list[i].instance == "STW") {
+            if (speedFormat == "m/s") {
+                // No conversion needed
+            } else if (speedFormat == "km/h") {
+                calibrationData.list[i].offset /= 3.6; // Convert km/h to m/s
+                calibrationData.list[i].slope /= 3.6; // Convert km/h to m/s
+            } else if (speedFormat == "kn") {
+                calibrationData.list[i].offset /= 1.94384; // Convert kn to m/s
+                calibrationData.list[i].slope /= 1.94384; // Convert kn to m/s
+            }
+        } else if (calibrationData.list[i].instance == "WTemp") {
+            if (tempFormat == "K" || tempFormat == "C") {
+                // No conversion needed
+            } else if (tempFormat == "F") {
+                calibrationData.list[i].offset *= 5.0 / 9.0; // Convert °F to K
+                calibrationData.list[i].slope *= 5.0 / 9.0;  // Convert °F to K
+            }
+        }
+        calibrationData.list[i].isCalibrated = false;
+
+        LOG_DEBUG(GwLog::LOG, "stored calibration data: %s, offset: %f, slope: %f", calibrationData.list[i].instance.c_str(), calibrationData.list[i].offset, calibrationData.list[i].slope);
+    }
+}
+
+int CalibrationDataList::getInstanceListNo(String instance)
+// Function to get the index of the requested instance in the list
+{
+
+    // Check if instance is in the list
+    for (int i = 0; i < maxCalibrationData; i++) {
+        if (calibrationData.list[i].instance == instance) {
+            return i;
+        }
+    }
+    return -1; // instance not found
+}
+
+/* void CalibrationDataList::updateBoatDataValidity(String instance)
+{
+    for (int i = 0; i < maxCalibrationData; i++) {
+        if (calibrationData.list[i].instance == instance) {
+            // test for boat data value validity - to be implemented
+            calibrationData.list[i].isValid = true;
+            return;
+        }
+    }
+} */
+
+void CalibrationDataList::calibrateInstance(String instance, GwApi::BoatValue* boatDataValue, GwLog* logger)
+// Function to calibrate the boat data value
+{
+    double offset = 0;
+    double slope = 1.0;
+
+    int listNo = getInstanceListNo(instance);
+    if (listNo >= 0) {
+        offset = calibrationData.list[listNo].offset;
+        slope = calibrationData.list[listNo].slope;
+
+        if (!boatDataValue->valid) { // no valid boat data value, so we don't want to apply calibration data
+            return;
+        } else {
+            boatDataValue->value = (boatDataValue->value * slope) + offset;
+            calibrationData.list[listNo].value = boatDataValue->value;
+            calibrationData.list[listNo].isCalibrated = true;
+            LOG_DEBUG(GwLog::LOG, "BoatDataCalibration: %s: Offset: %f Slope: %f Result: %f", instance.c_str(), offset, slope, boatDataValue->value);
+
+        }
+    } else {
+        LOG_DEBUG(GwLog::LOG, "BoatDataCalibration: %s not found in calibration data list", instance.c_str());
+    }
+}
+
+#endif

--- a/lib/obp60task/BoatDataCalibration.h
+++ b/lib/obp60task/BoatDataCalibration.h
@@ -25,7 +25,6 @@ public:
     static void calibrateInstance(String instance, GwApi::BoatValue* boatDataValue, GwLog* logger);
 
 private:
-//    GwLog* logger;
 };
 
 extern CalibrationDataList calibrationData; // this list holds all calibration data

--- a/lib/obp60task/BoatDataCalibration.h
+++ b/lib/obp60task/BoatDataCalibration.h
@@ -1,0 +1,33 @@
+// Functions lib for data instance calibration
+
+#ifndef _BOATDATACALIBRATION_H
+#define _BOATDATACALIBRATION_H
+
+#include "Pagedata.h"
+#include "WString.h"
+
+typedef struct {
+    String instance; // data type/instance to be calibrated
+    double offset; // calibration offset
+    double slope; // calibration slope
+    double value; // calibrated data value
+    bool isCalibrated; // is data instance value calibrated?
+} CalibData;
+
+const int maxCalibrationData = 3; // maximum number of calibration data instances
+
+class CalibrationDataList {
+public:
+    CalibData list[maxCalibrationData]; // list of calibration data instances
+
+    static void readConfig(GwConfigHandler* config, GwLog* logger);
+    static int getInstanceListNo(String instance);
+    static void calibrateInstance(String instance, GwApi::BoatValue* boatDataValue, GwLog* logger);
+
+private:
+//    GwLog* logger;
+};
+
+extern CalibrationDataList calibrationData; // this list holds all calibration data
+
+#endif

--- a/lib/obp60task/PageFourValues.cpp
+++ b/lib/obp60task/PageFourValues.cpp
@@ -2,6 +2,7 @@
 
 #include "Pagedata.h"
 #include "OBP60Extensions.h"
+#include "BoatDataCalibration.h"
 
 class PageFourValues : public Page
 {
@@ -47,6 +48,7 @@ class PageFourValues : public Page
         name1 = name1.substring(0, 6);                  // String length limit for value name
         double value1 = bvalue1->value;                 // Value as double in SI unit
         bool valid1 = bvalue1->valid;                   // Valid information 
+        CalibrationDataList::calibrateInstance(name1, bvalue1, logger); // Check if boat data value is to be calibrated
         String svalue1 = formatValue(bvalue1, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
         String unit1 = formatValue(bvalue1, *commonData).unit;        // Unit of value
 
@@ -56,6 +58,7 @@ class PageFourValues : public Page
         name2 = name2.substring(0, 6);                  // String length limit for value name
         double value2 = bvalue2->value;                 // Value as double in SI unit
         bool valid2 = bvalue2->valid;                   // Valid information 
+        CalibrationDataList::calibrateInstance(name2, bvalue2, logger); // Check if boat data value is to be calibrated
         String svalue2 = formatValue(bvalue2, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
         String unit2 = formatValue(bvalue2, *commonData).unit;        // Unit of value
 
@@ -65,6 +68,7 @@ class PageFourValues : public Page
         name3 = name3.substring(0, 6);                  // String length limit for value name
         double value3 = bvalue3->value;                 // Value as double in SI unit
         bool valid3 = bvalue3->valid;                   // Valid information 
+        CalibrationDataList::calibrateInstance(name3, bvalue3, logger); // Check if boat data value is to be calibrated
         String svalue3 = formatValue(bvalue3, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
         String unit3 = formatValue(bvalue3, *commonData).unit;        // Unit of value
 
@@ -74,6 +78,7 @@ class PageFourValues : public Page
         name4 = name4.substring(0, 6);                  // String length limit for value name
         double value4 = bvalue4->value;                 // Value as double in SI unit
         bool valid4 = bvalue4->valid;                   // Valid information 
+        CalibrationDataList::calibrateInstance(name4, bvalue4, logger); // Check if boat data value is to be calibrated
         String svalue4 = formatValue(bvalue4, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
         String unit4 = formatValue(bvalue4, *commonData).unit;        // Unit of value
 

--- a/lib/obp60task/PageFourValues.cpp
+++ b/lib/obp60task/PageFourValues.cpp
@@ -48,7 +48,7 @@ class PageFourValues : public Page
         name1 = name1.substring(0, 6);                  // String length limit for value name
         double value1 = bvalue1->value;                 // Value as double in SI unit
         bool valid1 = bvalue1->valid;                   // Valid information 
-        CalibrationDataList::calibrateInstance(name1, bvalue1, logger); // Check if boat data value is to be calibrated
+        calibrationData.calibrateInstance(name1, bvalue1, logger); // Check if boat data value is to be calibrated
         String svalue1 = formatValue(bvalue1, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
         String unit1 = formatValue(bvalue1, *commonData).unit;        // Unit of value
 
@@ -58,7 +58,7 @@ class PageFourValues : public Page
         name2 = name2.substring(0, 6);                  // String length limit for value name
         double value2 = bvalue2->value;                 // Value as double in SI unit
         bool valid2 = bvalue2->valid;                   // Valid information 
-        CalibrationDataList::calibrateInstance(name2, bvalue2, logger); // Check if boat data value is to be calibrated
+        calibrationData.calibrateInstance(name2, bvalue2, logger); // Check if boat data value is to be calibrated
         String svalue2 = formatValue(bvalue2, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
         String unit2 = formatValue(bvalue2, *commonData).unit;        // Unit of value
 
@@ -68,7 +68,7 @@ class PageFourValues : public Page
         name3 = name3.substring(0, 6);                  // String length limit for value name
         double value3 = bvalue3->value;                 // Value as double in SI unit
         bool valid3 = bvalue3->valid;                   // Valid information 
-        CalibrationDataList::calibrateInstance(name3, bvalue3, logger); // Check if boat data value is to be calibrated
+        calibrationData.calibrateInstance(name3, bvalue3, logger); // Check if boat data value is to be calibrated
         String svalue3 = formatValue(bvalue3, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
         String unit3 = formatValue(bvalue3, *commonData).unit;        // Unit of value
 
@@ -78,7 +78,7 @@ class PageFourValues : public Page
         name4 = name4.substring(0, 6);                  // String length limit for value name
         double value4 = bvalue4->value;                 // Value as double in SI unit
         bool valid4 = bvalue4->valid;                   // Valid information 
-        CalibrationDataList::calibrateInstance(name4, bvalue4, logger); // Check if boat data value is to be calibrated
+        calibrationData.calibrateInstance(name4, bvalue4, logger); // Check if boat data value is to be calibrated
         String svalue4 = formatValue(bvalue4, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
         String unit4 = formatValue(bvalue4, *commonData).unit;        // Unit of value
 

--- a/lib/obp60task/PageFourValues2.cpp
+++ b/lib/obp60task/PageFourValues2.cpp
@@ -2,6 +2,7 @@
 
 #include "Pagedata.h"
 #include "OBP60Extensions.h"
+#include "BoatDataCalibration.h"
 
 class PageFourValues2 : public Page
 {
@@ -47,6 +48,7 @@ class PageFourValues2 : public Page
         name1 = name1.substring(0, 6);                  // String length limit for value name
         double value1 = bvalue1->value;                 // Value as double in SI unit
         bool valid1 = bvalue1->valid;                   // Valid information 
+        CalibrationDataList::calibrateInstance(name1, bvalue1, logger); // Check if boat data value is to be calibrated
         String svalue1 = formatValue(bvalue1, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
         String unit1 = formatValue(bvalue1, *commonData).unit;        // Unit of value
 
@@ -56,6 +58,7 @@ class PageFourValues2 : public Page
         name2 = name2.substring(0, 6);                  // String length limit for value name
         double value2 = bvalue2->value;                 // Value as double in SI unit
         bool valid2 = bvalue2->valid;                   // Valid information 
+        CalibrationDataList::calibrateInstance(name2, bvalue2, logger); // Check if boat data value is to be calibrated
         String svalue2 = formatValue(bvalue2, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
         String unit2 = formatValue(bvalue2, *commonData).unit;        // Unit of value
 
@@ -65,6 +68,7 @@ class PageFourValues2 : public Page
         name3 = name3.substring(0, 6);                  // String length limit for value name
         double value3 = bvalue3->value;                 // Value as double in SI unit
         bool valid3 = bvalue3->valid;                   // Valid information 
+        CalibrationDataList::calibrateInstance(name3, bvalue3, logger); // Check if boat data value is to be calibrated
         String svalue3 = formatValue(bvalue3, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
         String unit3 = formatValue(bvalue3, *commonData).unit;        // Unit of value
 
@@ -74,6 +78,7 @@ class PageFourValues2 : public Page
         name4 = name4.substring(0, 6);                  // String length limit for value name
         double value4 = bvalue4->value;                 // Value as double in SI unit
         bool valid4 = bvalue4->valid;                   // Valid information 
+        CalibrationDataList::calibrateInstance(name4, bvalue4, logger); // Check if boat data value is to be calibrated
         String svalue4 = formatValue(bvalue4, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
         String unit4 = formatValue(bvalue4, *commonData).unit;        // Unit of value
 

--- a/lib/obp60task/PageFourValues2.cpp
+++ b/lib/obp60task/PageFourValues2.cpp
@@ -48,7 +48,7 @@ class PageFourValues2 : public Page
         name1 = name1.substring(0, 6);                  // String length limit for value name
         double value1 = bvalue1->value;                 // Value as double in SI unit
         bool valid1 = bvalue1->valid;                   // Valid information 
-        CalibrationDataList::calibrateInstance(name1, bvalue1, logger); // Check if boat data value is to be calibrated
+        calibrationData.calibrateInstance(name1, bvalue1, logger); // Check if boat data value is to be calibrated
         String svalue1 = formatValue(bvalue1, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
         String unit1 = formatValue(bvalue1, *commonData).unit;        // Unit of value
 
@@ -58,7 +58,7 @@ class PageFourValues2 : public Page
         name2 = name2.substring(0, 6);                  // String length limit for value name
         double value2 = bvalue2->value;                 // Value as double in SI unit
         bool valid2 = bvalue2->valid;                   // Valid information 
-        CalibrationDataList::calibrateInstance(name2, bvalue2, logger); // Check if boat data value is to be calibrated
+        calibrationData.calibrateInstance(name2, bvalue2, logger); // Check if boat data value is to be calibrated
         String svalue2 = formatValue(bvalue2, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
         String unit2 = formatValue(bvalue2, *commonData).unit;        // Unit of value
 
@@ -68,7 +68,7 @@ class PageFourValues2 : public Page
         name3 = name3.substring(0, 6);                  // String length limit for value name
         double value3 = bvalue3->value;                 // Value as double in SI unit
         bool valid3 = bvalue3->valid;                   // Valid information 
-        CalibrationDataList::calibrateInstance(name3, bvalue3, logger); // Check if boat data value is to be calibrated
+        calibrationData.calibrateInstance(name3, bvalue3, logger); // Check if boat data value is to be calibrated
         String svalue3 = formatValue(bvalue3, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
         String unit3 = formatValue(bvalue3, *commonData).unit;        // Unit of value
 
@@ -78,7 +78,7 @@ class PageFourValues2 : public Page
         name4 = name4.substring(0, 6);                  // String length limit for value name
         double value4 = bvalue4->value;                 // Value as double in SI unit
         bool valid4 = bvalue4->valid;                   // Valid information 
-        CalibrationDataList::calibrateInstance(name4, bvalue4, logger); // Check if boat data value is to be calibrated
+        calibrationData.calibrateInstance(name4, bvalue4, logger); // Check if boat data value is to be calibrated
         String svalue4 = formatValue(bvalue4, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
         String unit4 = formatValue(bvalue4, *commonData).unit;        // Unit of value
 

--- a/lib/obp60task/PageOneValue.cpp
+++ b/lib/obp60task/PageOneValue.cpp
@@ -40,9 +40,9 @@ class PageOneValue : public Page
         GwApi::BoatValue *bvalue1 = pageData.values[0]; // First element in list (only one value by PageOneValue)
         String name1 = xdrDelete(bvalue1->getName());   // Value name
         name1 = name1.substring(0, 6);                  // String length limit for value name
-        double value1 = bvalue1->value;                 // Value as double in SI unit
-        bool valid1 = bvalue1->valid;                   // Valid information 
-        CalibrationDataList::calibrateInstance(name1, bvalue1, logger); // Check if boat data value is to be calibrated
+//        double value1 = bvalue1->value;                 // Value as double in SI unit
+        bool valid1 = bvalue1->valid;                   // Valid information
+        calibrationData.calibrateInstance(name1, bvalue1, logger); // Check if boat data value is to be calibrated
         String svalue1 = formatValue(bvalue1, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
         String unit1 = formatValue(bvalue1, *commonData).unit;        // Unit of value
 
@@ -54,7 +54,7 @@ class PageOneValue : public Page
 
         // Logging boat values
         if (bvalue1 == NULL) return;
-        LOG_DEBUG(GwLog::LOG,"Drawing at PageOneValue, %s: %f", name1.c_str(), value1);
+        LOG_DEBUG(GwLog::LOG,"Drawing at PageOneValue, %s: %f", name1.c_str(), bvalue1);
 
         // Draw page
         //***********************************************************

--- a/lib/obp60task/PageOneValue.cpp
+++ b/lib/obp60task/PageOneValue.cpp
@@ -2,6 +2,7 @@
 
 #include "Pagedata.h"
 #include "OBP60Extensions.h"
+#include "BoatDataCalibration.h"
 
 class PageOneValue : public Page
 {
@@ -41,6 +42,7 @@ class PageOneValue : public Page
         name1 = name1.substring(0, 6);                  // String length limit for value name
         double value1 = bvalue1->value;                 // Value as double in SI unit
         bool valid1 = bvalue1->valid;                   // Valid information 
+        CalibrationDataList::calibrateInstance(name1, bvalue1, logger); // Check if boat data value is to be calibrated
         String svalue1 = formatValue(bvalue1, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
         String unit1 = formatValue(bvalue1, *commonData).unit;        // Unit of value
 

--- a/lib/obp60task/PageSixValues.cpp
+++ b/lib/obp60task/PageSixValues.cpp
@@ -2,6 +2,7 @@
 
 #include "Pagedata.h"
 #include "OBP60Extensions.h"
+#include "BoatDataCalibration.h"
 
 #include "DSEG7Classic-BoldItalic26pt7b.h"
 
@@ -61,6 +62,7 @@ class PageSixValues : public Page
                 DataName[i] = xdrDelete(bvalue->getName());
                 DataName[i] = DataName[i].substring(0, 6);                  // String length limit for value name
                 DataValue[i] = bvalue->value;                 // Value as double in SI unit
+                calibrationData.calibrateInstance(DataName[i], bvalue, logger); // Check if boat data value is to be calibrated
                 DataValid[i] = bvalue->valid;
                 DataText[i] = formatValue(bvalue, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
                 DataUnits[i] = formatValue(bvalue, *commonData).unit;   

--- a/lib/obp60task/PageThreeValues.cpp
+++ b/lib/obp60task/PageThreeValues.cpp
@@ -2,6 +2,7 @@
 
 #include "Pagedata.h"
 #include "OBP60Extensions.h"
+#include "BoatDataCalibration.h"
 
 class PageThreeValues : public Page
 {
@@ -45,6 +46,7 @@ class PageThreeValues : public Page
         name1 = name1.substring(0, 6);                  // String length limit for value name
         double value1 = bvalue1->value;                 // Value as double in SI unit
         bool valid1 = bvalue1->valid;                   // Valid information 
+        CalibrationDataList::calibrateInstance(name1, bvalue1, logger); // Check if boat data value is to be calibrated
         String svalue1 = formatValue(bvalue1, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
         String unit1 = formatValue(bvalue1, *commonData).unit;        // Unit of value
 
@@ -54,6 +56,7 @@ class PageThreeValues : public Page
         name2 = name2.substring(0, 6);                  // String length limit for value name
         double value2 = bvalue2->value;                 // Value as double in SI unit
         bool valid2 = bvalue2->valid;                   // Valid information 
+        CalibrationDataList::calibrateInstance(name2, bvalue2, logger); // Check if boat data value is to be calibrated
         String svalue2 = formatValue(bvalue2, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
         String unit2 = formatValue(bvalue2, *commonData).unit;        // Unit of value
 
@@ -63,6 +66,7 @@ class PageThreeValues : public Page
         name3 = name3.substring(0, 6);                  // String length limit for value name
         double value3 = bvalue3->value;                 // Value as double in SI unit
         bool valid3 = bvalue3->valid;                   // Valid information 
+        CalibrationDataList::calibrateInstance(name3, bvalue3, logger); // Check if boat data value is to be calibrated
         String svalue3 = formatValue(bvalue3, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
         String unit3 = formatValue(bvalue3, *commonData).unit;        // Unit of value
 

--- a/lib/obp60task/PageThreeValues.cpp
+++ b/lib/obp60task/PageThreeValues.cpp
@@ -46,7 +46,7 @@ class PageThreeValues : public Page
         name1 = name1.substring(0, 6);                  // String length limit for value name
         double value1 = bvalue1->value;                 // Value as double in SI unit
         bool valid1 = bvalue1->valid;                   // Valid information 
-        CalibrationDataList::calibrateInstance(name1, bvalue1, logger); // Check if boat data value is to be calibrated
+        calibrationData.calibrateInstance(name1, bvalue1, logger); // Check if boat data value is to be calibrated
         String svalue1 = formatValue(bvalue1, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
         String unit1 = formatValue(bvalue1, *commonData).unit;        // Unit of value
 
@@ -56,7 +56,7 @@ class PageThreeValues : public Page
         name2 = name2.substring(0, 6);                  // String length limit for value name
         double value2 = bvalue2->value;                 // Value as double in SI unit
         bool valid2 = bvalue2->valid;                   // Valid information 
-        CalibrationDataList::calibrateInstance(name2, bvalue2, logger); // Check if boat data value is to be calibrated
+        calibrationData.calibrateInstance(name2, bvalue2, logger); // Check if boat data value is to be calibrated
         String svalue2 = formatValue(bvalue2, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
         String unit2 = formatValue(bvalue2, *commonData).unit;        // Unit of value
 
@@ -66,7 +66,7 @@ class PageThreeValues : public Page
         name3 = name3.substring(0, 6);                  // String length limit for value name
         double value3 = bvalue3->value;                 // Value as double in SI unit
         bool valid3 = bvalue3->valid;                   // Valid information 
-        CalibrationDataList::calibrateInstance(name3, bvalue3, logger); // Check if boat data value is to be calibrated
+        calibrationData.calibrateInstance(name3, bvalue3, logger); // Check if boat data value is to be calibrated
         String svalue3 = formatValue(bvalue3, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
         String unit3 = formatValue(bvalue3, *commonData).unit;        // Unit of value
 

--- a/lib/obp60task/PageTwoValues.cpp
+++ b/lib/obp60task/PageTwoValues.cpp
@@ -44,7 +44,7 @@ class PageTwoValues : public Page
         name1 = name1.substring(0, 6);                  // String length limit for value name
         double value1 = bvalue1->value;                 // Value as double in SI unit
         bool valid1 = bvalue1->valid;                   // Valid information 
-        CalibrationDataList::calibrateInstance(name1, bvalue1, logger); // Check if boat data value is to be calibrated
+        calibrationData.calibrateInstance(name1, bvalue1, logger); // Check if boat data value is to be calibrated
         String svalue1 = formatValue(bvalue1, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
         String unit1 = formatValue(bvalue1, *commonData).unit;        // Unit of value
 
@@ -54,7 +54,7 @@ class PageTwoValues : public Page
         name2 = name2.substring(0, 6);                  // String length limit for value name
         double value2 = bvalue2->value;                 // Value as double in SI unit
         bool valid2 = bvalue2->valid;                   // Valid information 
-        CalibrationDataList::calibrateInstance(name2, bvalue2, logger); // Check if boat data value is to be calibrated
+        calibrationData.calibrateInstance(name2, bvalue2, logger); // Check if boat data value is to be calibrated
         String svalue2 = formatValue(bvalue2, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
         String unit2 = formatValue(bvalue2, *commonData).unit;        // Unit of value
 

--- a/lib/obp60task/PageTwoValues.cpp
+++ b/lib/obp60task/PageTwoValues.cpp
@@ -2,6 +2,7 @@
 
 #include "Pagedata.h"
 #include "OBP60Extensions.h"
+#include "BoatDataCalibration.h"
 
 class PageTwoValues : public Page
 {
@@ -43,6 +44,7 @@ class PageTwoValues : public Page
         name1 = name1.substring(0, 6);                  // String length limit for value name
         double value1 = bvalue1->value;                 // Value as double in SI unit
         bool valid1 = bvalue1->valid;                   // Valid information 
+        CalibrationDataList::calibrateInstance(name1, bvalue1, logger); // Check if boat data value is to be calibrated
         String svalue1 = formatValue(bvalue1, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
         String unit1 = formatValue(bvalue1, *commonData).unit;        // Unit of value
 
@@ -52,6 +54,7 @@ class PageTwoValues : public Page
         name2 = name2.substring(0, 6);                  // String length limit for value name
         double value2 = bvalue2->value;                 // Value as double in SI unit
         bool valid2 = bvalue2->valid;                   // Valid information 
+        CalibrationDataList::calibrateInstance(name2, bvalue2, logger); // Check if boat data value is to be calibrated
         String svalue2 = formatValue(bvalue2, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
         String unit2 = formatValue(bvalue2, *commonData).unit;        // Unit of value
 

--- a/lib/obp60task/PageWind.cpp
+++ b/lib/obp60task/PageWind.cpp
@@ -3,6 +3,7 @@
 #include "Pagedata.h"
 #include "OBP60Extensions.h"
 #include "N2kMessages.h"
+#include "BoatDataCalibration.h"
 
 #define front_width 120
 #define front_height 162
@@ -323,6 +324,7 @@ public:
         }
         String name1 = bvalue1->getName().c_str();      // Value name
         name1 = name1.substring(0, 6);                  // String length limit for value name
+        calibrationData.calibrateInstance(name1, bvalue1, logger); // Check if boat data value is to be calibrated
         double value1 = bvalue1->value;                 // Value as double in SI unit
         // bool valid1 = bvalue1->valid;                   // Valid information
         String svalue1 = formatValue(bvalue1, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
@@ -336,6 +338,7 @@ public:
         }
         String name2 = bvalue2->getName().c_str();      // Value name
         name2 = name2.substring(0, 6);                  // String length limit for value name
+        calibrationData.calibrateInstance(name2, bvalue2, logger); // Check if boat data value is to be calibrated
         double value2 = bvalue2->value;                 // Value as double in SI unit
         // bool valid2 = bvalue2->valid;                   // Valid information
         if (simulation) {

--- a/lib/obp60task/PageWindRose.cpp
+++ b/lib/obp60task/PageWindRose.cpp
@@ -2,6 +2,7 @@
 
 #include "Pagedata.h"
 #include "OBP60Extensions.h"
+#include "BoatDataCalibration.h"
 
 class PageWindRose : public Page
 {
@@ -51,6 +52,7 @@ public:
         GwApi::BoatValue *bvalue1 = pageData.values[0]; // First element in list (only one value by PageOneValue)
         String name1 = xdrDelete(bvalue1->getName());   // Value name
         name1 = name1.substring(0, 6);                  // String length limit for value name
+        calibrationData.calibrateInstance(name1, bvalue1, logger); // Check if boat data value is to be calibrated
         double value1 = bvalue1->value;                 // Value as double in SI unit
         bool valid1 = bvalue1->valid;                   // Valid information
         value1 = formatValue(bvalue1, *commonData).value;// Format only nesaccery for simulation data for pointer
@@ -65,6 +67,7 @@ public:
         GwApi::BoatValue *bvalue2 = pageData.values[1]; // First element in list (only one value by PageOneValue)
         String name2 = xdrDelete(bvalue2->getName());   // Value name
         name2 = name2.substring(0, 6);                  // String length limit for value name
+        calibrationData.calibrateInstance(name2, bvalue2, logger); // Check if boat data value is to be calibrated
         double value2 = bvalue2->value;                 // Value as double in SI unit
         bool valid2 = bvalue2->valid;                   // Valid information 
         String svalue2 = formatValue(bvalue2, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
@@ -78,6 +81,7 @@ public:
         GwApi::BoatValue *bvalue3 = pageData.values[2]; // Second element in list (only one value by PageOneValue)
         String name3 = xdrDelete(bvalue3->getName());   // Value name
         name3 = name3.substring(0, 6);                  // String length limit for value name
+        calibrationData.calibrateInstance(name3, bvalue3, logger); // Check if boat data value is to be calibrated
         double value3 = bvalue3->value;                 // Value as double in SI unit
         bool valid3 = bvalue3->valid;                   // Valid information 
         String svalue3 = formatValue(bvalue3, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
@@ -91,6 +95,7 @@ public:
         GwApi::BoatValue *bvalue4 = pageData.values[3]; // Second element in list (only one value by PageOneValue)
         String name4 = xdrDelete(bvalue4->getName());      // Value name
         name4 = name4.substring(0, 6);                  // String length limit for value name
+        calibrationData.calibrateInstance(name4, bvalue4, logger); // Check if boat data value is to be calibrated
         double value4 = bvalue4->value;                 // Value as double in SI unit
         bool valid4 = bvalue4->valid;                   // Valid information 
         String svalue4 = formatValue(bvalue4, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
@@ -104,6 +109,7 @@ public:
         GwApi::BoatValue *bvalue5 = pageData.values[4]; // Second element in list (only one value by PageOneValue)
         String name5 = xdrDelete(bvalue5->getName());      // Value name
         name5 = name5.substring(0, 6);                  // String length limit for value name
+        calibrationData.calibrateInstance(name5, bvalue5, logger); // Check if boat data value is to be calibrated
         double value5 = bvalue5->value;                 // Value as double in SI unit
         bool valid5 = bvalue5->valid;                   // Valid information 
         String svalue5 = formatValue(bvalue5, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
@@ -117,6 +123,7 @@ public:
         GwApi::BoatValue *bvalue6 = pageData.values[5]; // Second element in list (only one value by PageOneValue)
         String name6 = xdrDelete(bvalue6->getName());      // Value name
         name6 = name6.substring(0, 6);                  // String length limit for value name
+        calibrationData.calibrateInstance(name6, bvalue6, logger); // Check if boat data value is to be calibrated
         double value6 = bvalue6->value;                 // Value as double in SI unit
         bool valid6 = bvalue6->valid;                   // Valid information 
         String svalue6 = formatValue(bvalue6, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places

--- a/lib/obp60task/PageWindRoseFlex.cpp
+++ b/lib/obp60task/PageWindRoseFlex.cpp
@@ -2,6 +2,7 @@
 
 #include "Pagedata.h"
 #include "OBP60Extensions.h"
+#include "BoatDataCalibration.h"
 
 class PageWindRoseFlex : public Page
 {
@@ -51,6 +52,7 @@ public:
         GwApi::BoatValue *bvalue1 = pageData.values[0]; // First element in list (only one value by PageOneValue)
         String name1 = xdrDelete(bvalue1->getName());   // Value name
         name1 = name1.substring(0, 6);                  // String length limit for value name
+        calibrationData.calibrateInstance(name1, bvalue1, logger); // Check if boat data value is to be calibrated
         double value1 = bvalue1->value;                 // Value as double in SI unit
         bool valid1 = bvalue1->valid;                   // Valid information
         value1 = formatValue(bvalue1, *commonData).value;// Format only nesaccery for simulation data for pointer
@@ -65,6 +67,7 @@ public:
         GwApi::BoatValue *bvalue2 = pageData.values[1]; // First element in list (only one value by PageOneValue)
         String name2 = xdrDelete(bvalue2->getName());   // Value name
         name2 = name2.substring(0, 6);                  // String length limit for value name
+        calibrationData.calibrateInstance(name2, bvalue2, logger); // Check if boat data value is to be calibrated
         double value2 = bvalue2->value;                 // Value as double in SI unit
         bool valid2 = bvalue2->valid;                   // Valid information 
         String svalue2 = formatValue(bvalue2, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
@@ -78,6 +81,7 @@ public:
         GwApi::BoatValue *bvalue3 = pageData.values[2]; // Second element in list (only one value by PageOneValue)
         String name3 = xdrDelete(bvalue3->getName());   // Value name
         name3 = name3.substring(0, 6);                  // String length limit for value name
+        calibrationData.calibrateInstance(name3, bvalue3, logger); // Check if boat data value is to be calibrated
         double value3 = bvalue3->value;                 // Value as double in SI unit
         bool valid3 = bvalue3->valid;                   // Valid information 
         String svalue3 = formatValue(bvalue3, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
@@ -91,6 +95,7 @@ public:
         GwApi::BoatValue *bvalue4 = pageData.values[3]; // Second element in list (only one value by PageOneValue)
         String name4 = xdrDelete(bvalue4->getName());      // Value name
         name4 = name4.substring(0, 6);                  // String length limit for value name
+        calibrationData.calibrateInstance(name4, bvalue4, logger); // Check if boat data value is to be calibrated
         double value4 = bvalue4->value;                 // Value as double in SI unit
         bool valid4 = bvalue4->valid;                   // Valid information 
         String svalue4 = formatValue(bvalue4, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
@@ -104,6 +109,7 @@ public:
         GwApi::BoatValue *bvalue5 = pageData.values[4]; // Second element in list (only one value by PageOneValue)
         String name5 = xdrDelete(bvalue5->getName());      // Value name
         name5 = name5.substring(0, 6);                  // String length limit for value name
+        calibrationData.calibrateInstance(name5, bvalue5, logger); // Check if boat data value is to be calibrated
         double value5 = bvalue5->value;                 // Value as double in SI unit
         bool valid5 = bvalue5->valid;                   // Valid information 
         String svalue5 = formatValue(bvalue5, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
@@ -117,6 +123,7 @@ public:
         GwApi::BoatValue *bvalue6 = pageData.values[5]; // Second element in list (only one value by PageOneValue)
         String name6 = xdrDelete(bvalue6->getName());      // Value name
         name6 = name6.substring(0, 6);                  // String length limit for value name
+        calibrationData.calibrateInstance(name6, bvalue6, logger); // Check if boat data value is to be calibrated
         double value6 = bvalue6->value;                 // Value as double in SI unit
         bool valid6 = bvalue6->valid;                   // Valid information 
         String svalue6 = formatValue(bvalue6, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places

--- a/lib/obp60task/config.json
+++ b/lib/obp60task/config.json
@@ -220,6 +220,17 @@
         }
     },
     {
+        "name": "calOffsetDBT",
+        "label": "Offset DBT",
+        "type": "number",
+        "default": "0.00",
+        "description": "Offset for depth transducer; positive for depth from surface, negative for depth below keel",
+        "category": "OBP60 Settings",
+        "capabilities": {
+            "obp60":"true"
+        }
+    },
+    {
         "name": "lengthFormat",
         "label": "Length Format",
         "type": "list",
@@ -687,6 +698,86 @@
         }
     },
     {
+        "name": "calInstance1",
+        "label": "Calibration Data Instance 1",
+        "type": "list",
+        "default": "",
+        "description": "Data instance for calibration",
+        "list": [
+            "AWA",
+            "AWS",
+            "HDM",
+            "STW",
+            "WTemp"
+        ],
+        "category": "OBP60 Calibrations",
+        "capabilities": {
+            "obp60":"true"
+        }
+    },
+    {
+        "name": "calOffset1",
+        "label": "Calibration Data Instance 1 Offset",
+        "type": "number",
+        "default": "0.00",
+        "description": "Offset for data instance 1",
+        "category": "OBP60 Calibrations",
+        "capabilities": {
+            "obp60":"true"
+        }
+    },
+    {
+        "name": "calSlope1",
+        "label": "Calibration Data Instance 1 Slope",
+        "type": "number",
+        "default": "1.00",
+        "description": "Slope for data instance 1",
+        "category": "OBP60 Calibrations",
+        "capabilities": {
+            "obp60":"true"
+        }
+    },
+    {
+        "name": "calInstance2",
+        "label": "Calibration Data Instance 2",
+        "type": "list",
+        "default": "",
+        "description": "Data instance for calibration",
+        "list": [
+            "AWA",
+            "AWS",
+            "HDM",
+            "STW",
+            "WTemp"
+        ],
+        "category": "OBP60 Calibrations",
+        "capabilities": {
+            "obp60":"true"
+        }
+    },
+    {
+        "name": "calOffset2",
+        "label": "Calibration Data Instance 2 Offset",
+        "type": "number",
+        "default": "0.00",
+        "description": "Offset for data instance 2",
+        "category": "OBP60 Calibrations",
+        "capabilities": {
+            "obp60":"true"
+        }
+    },
+    {
+        "name": "calSlope2",
+        "label": "Calibration Data Instance 2 Slope",
+        "type": "number",
+        "default": "1.00",
+        "description": "Slope for data instance 2",
+        "category": "OBP60 Calibrations",
+        "capabilities": {
+            "obp60":"true"
+        }
+    },
+{
         "name": "display",
         "label": "Display Mode",
         "type": "list",

--- a/lib/obp60task/config.json
+++ b/lib/obp60task/config.json
@@ -698,6 +698,9 @@
             "DBT",
             "HDM",
             "STW",
+            "TWA",
+            "TWS",
+            "TWD",
             "WTemp"
         ],
         "category": "OBP60 Calibrations",
@@ -739,6 +742,9 @@
             "DBT",
             "HDM",
             "STW",
+            "TWA",
+            "TWS",
+            "TWD",
             "WTemp"
         ],
         "category": "OBP60 Calibrations",
@@ -780,6 +786,9 @@
             "DBT",
             "HDM",
             "STW",
+            "TWA",
+            "TWS",
+            "TWD",
             "WTemp"
         ],
         "category": "OBP60 Calibrations",

--- a/lib/obp60task/config.json
+++ b/lib/obp60task/config.json
@@ -220,17 +220,6 @@
         }
     },
     {
-        "name": "calOffsetDBT",
-        "label": "Offset DBT",
-        "type": "number",
-        "default": "0.00",
-        "description": "Offset for depth transducer; positive for depth from surface, negative for depth below keel",
-        "category": "OBP60 Settings",
-        "capabilities": {
-            "obp60":"true"
-        }
-    },
-    {
         "name": "lengthFormat",
         "label": "Length Format",
         "type": "list",
@@ -706,6 +695,7 @@
         "list": [
             "AWA",
             "AWS",
+            "DBT",
             "HDM",
             "STW",
             "WTemp"
@@ -746,6 +736,7 @@
         "list": [
             "AWA",
             "AWS",
+            "DBT",
             "HDM",
             "STW",
             "WTemp"
@@ -772,6 +763,47 @@
         "type": "number",
         "default": "1.00",
         "description": "Slope for data instance 2",
+        "category": "OBP60 Calibrations",
+        "capabilities": {
+            "obp60":"true"
+        }
+    },
+    {
+        "name": "calInstance3",
+        "label": "Calibration Data Instance 3",
+        "type": "list",
+        "default": "",
+        "description": "Data instance for calibration",
+        "list": [
+            "AWA",
+            "AWS",
+            "DBT",
+            "HDM",
+            "STW",
+            "WTemp"
+        ],
+        "category": "OBP60 Calibrations",
+        "capabilities": {
+            "obp60":"true"
+        }
+    },
+    {
+        "name": "calOffset3",
+        "label": "Calibration Data Instance 3 Offset",
+        "type": "number",
+        "default": "0.00",
+        "description": "Offset for data instance 3",
+        "category": "OBP60 Calibrations",
+        "capabilities": {
+            "obp60":"true"
+        }
+    },
+    {
+        "name": "calSlope3",
+        "label": "Calibration Data Instance 3 Slope",
+        "type": "number",
+        "default": "1.00",
+        "description": "Slope for data instance 3",
         "category": "OBP60 Calibrations",
         "capabilities": {
             "obp60":"true"

--- a/lib/obp60task/obp60task.cpp
+++ b/lib/obp60task/obp60task.cpp
@@ -12,6 +12,7 @@
 #include <GxEPD2_BW.h>                  // GxEPD2 lib for b/w E-Ink displays
 #include "OBP60Extensions.h"            // Functions lib for extension board
 #include "OBP60Keypad.h"                // Functions for keypad
+#include "BoatDataCalibration.h"        // Functions lib for data instance calibration
 
 #ifdef BOARD_OBP40S3
 #include "driver/rtc_io.h"              // Needs for weakup from deep sleep
@@ -384,6 +385,10 @@ void OBP60Task(GwApi *api){
     CommonData commonData;
     commonData.logger=logger;
     commonData.config=config;
+
+    // Read all calibration data settings from config
+    CalibrationDataList::readConfig(config, logger);
+    LOG_DEBUG(GwLog::LOG,"Calibration data read from config");
 
 #ifdef HARDWARE_V21
     // Keyboard coordinates for page footer

--- a/lib/obp60task/obp60task.cpp
+++ b/lib/obp60task/obp60task.cpp
@@ -386,10 +386,6 @@ void OBP60Task(GwApi *api){
     commonData.logger=logger;
     commonData.config=config;
 
-    // Read all calibration data settings from config
-    CalibrationDataList::readConfig(config, logger);
-    LOG_DEBUG(GwLog::LOG,"Calibration data read from config");
-
 #ifdef HARDWARE_V21
     // Keyboard coordinates for page footer
     initKeys(commonData);
@@ -528,6 +524,9 @@ void OBP60Task(GwApi *api){
     }
     // add out of band system page (always available)
     Page *syspage = allPages.pages[0]->creator(commonData);
+
+    // Read all calibration data settings from config
+    calibrationData.readConfig(config, logger);
 
     // Display screenshot handler for HTTP request
     // http://192.168.15.1/api/user/OBP60Task/screenshot


### PR DESCRIPTION
This implements basic principle for calibration of certain data types.
The current state is a request for comments. It needs to be extended to all page types and for more data types.

It implements config values to specify offset and slope for up to three boat data types.
These config values are initially read during start of obp60class with a method of a new class <calibrationDataList>.
Then, each time when a page displays data, the respective data values are checked for calibration. Calibration can be activated on a page with a single method call for each value.

Currently, calibration can be set for 3 different data types. This can be extended.
So far, I implemented it for page types PageOneValue, PageTwoValues, PageThreeValues, PageFourValues, PageFourValues2, PageSixValues.

Provide your comments. Is it implemented correctly following the principles for user extension of the nmea2000 gateway?
Does it make sense this way?