### PR TITLE
PageSixValues: Drop top and bottom line to adjust to standard page design

### DIFF
--- a/lib/obp60task/PageSixValues.cpp
+++ b/lib/obp60task/PageSixValues.cpp
@@ -85,9 +85,10 @@ class PageSixValues : public Page
             getdisplay().setTextColor(commonData->fgcolor);
 
             for (int i = 0; i < ( HowManyValues / 2 ); i++){
-       // Horizontal line 3 pix
-                getdisplay().fillRect(0, SixValues_y1+i*SixValues_DeltaY, 400, 3, commonData->fgcolor);
-    
+                if (i < (HowManyValues / 2) - 1) {          // Don't draw horizontal line after last line of values -> standard design
+                   // Horizontal line 3 pix
+                    getdisplay().fillRect(0, SixValues_y1+(i+1)*SixValues_DeltaY, 400, 3, commonData->fgcolor);
+                }
                 for (int j = 0; j < 2; j++){
                     int ValueIndex = i * 2 + j;
                     int x0 = SixValues_x1 + j * SixValues_DeltaX;
@@ -151,7 +152,6 @@ class PageSixValues : public Page
                    // Vertical line 3 pix
             getdisplay().fillRect(SixValues_x1+SixValues_DeltaX-8, SixValues_y1+i*SixValues_DeltaY, 3, SixValues_DeltaY, commonData->fgcolor);
             }
-            getdisplay().fillRect(0, SixValues_y1+3*SixValues_DeltaY, 400, 3, commonData->fgcolor);
     
             // Update display
             getdisplay().nextPage();    // Partial update (fast)


### PR DESCRIPTION
The current design of 'PageSixValues' draws a line below the top status line and another one above of the bottom status line. All other page designs don't separate the status lines from the central page content.

Therefore, this adjustment doesn't draw these two horizontal lines, but only the two lines to separate the three rows of data values. 