### PR TITLE
WindRoseFlex: less clutter, display A or T in the cetner

### DIFF
--- a/lib/obp60task/PageWindRoseFlex.cpp
+++ b/lib/obp60task/PageWindRoseFlex.cpp
@@ -8,7 +8,6 @@ class PageWindRoseFlex : public Page
 {
 int16_t lp = 80;                    // Pointer length
 char source = 'A';		    // data source (A)pparent | (T)rue
-String 	ssource="App.";		    // String for Data Source 
 
 public:
     PageWindRoseFlex(CommonData &common){
@@ -26,10 +25,8 @@ public:
 	 // Code for set source 
 	    if(source == 'A'){ 
 		    source = 'T'; 
-		    ssource = "True"; // String to display
 	    } else { 
 		    source = 'A'; 
-		    ssource = "App."; // String to display
 	    } 
 	   } 
 	return key;               // Commit the key
@@ -381,12 +378,22 @@ public:
         }
 
         // Center circle
-        getdisplay().fillCircle(200, 150, startwidth + 6, commonData->bgcolor);
-        getdisplay().fillCircle(200, 150, startwidth + 4, commonData->fgcolor);
+        getdisplay().fillCircle(200, 150, startwidth + 8, commonData->bgcolor);
+        getdisplay().fillCircle(200, 150, startwidth + 6, commonData->fgcolor);
+        getdisplay().fillCircle(200, 150, startwidth + 4, commonData->bgcolor);
+    	getdisplay().setFont(&Ubuntu_Bold10pt8b);
+    	if (source=='A'){
+		getdisplay().setCursor(193, 155);
+	}
+	else {
+		getdisplay().setCursor(195, 156);
+	}
+    	getdisplay().print({source}); 
+
 
 //*******************************************************************************************
 
-	// Show value6 (=fourth user-configured parameter) and ssource, so that they do not collide with the wind pointer
+	// Show value6 (=fourth user-configured parameter) 
 if ( cos(value1) > 0){ 
     //pointer points upwards 
     getdisplay().setFont(&DSEG7Classic_BoldItalic16pt7b);
@@ -401,13 +408,6 @@ if ( cos(value1) > 0){
     else{  
         getdisplay().print(unit6old);                // Unit
     }
-    if (sin(value1)>0){
-	    getdisplay().setCursor(160, 130);
-    }
-    else{
-	    getdisplay().setCursor(220, 130);
-    }
-    getdisplay().print(ssource);		// true or app.
 }
 else{ 
     // pointer points downwards
@@ -423,13 +423,6 @@ else{
     else{  
         getdisplay().print(unit6old);                // Unit
     }
-    if (sin(value1)>0){
-	    getdisplay().setCursor(160, 200);
-    }
-    else{
-	    getdisplay().setCursor(220, 200);
-    }
-    getdisplay().print(ssource);		//true or app. 
 }
 
         return PAGE_UPDATE;


### PR DESCRIPTION
Display a T or an A in the central dot of the windrose instead of writing "True" or "App" somewhere  in the free space