### PR TITLE
PageOneValue with graphical chart support + PageWindPlot v3

### DIFF
--- a/lib/obp60task/OBP60Extensions.cpp
+++ b/lib/obp60task/OBP60Extensions.cpp
@@ -434,7 +434,7 @@ void drawTextRalign(int16_t x, int16_t y, String text) {
     int16_t x1, y1;
     uint16_t w, h;
     getdisplay().getTextBounds(text, 0, 150, &x1, &y1, &w, &h);
-    getdisplay().setCursor(x - w, y);
+    getdisplay().setCursor(x - w - 1, y); // '-1' required since some strings wrap around w/o it
     getdisplay().print(text);
 }
 

--- a/lib/obp60task/OBP60Formatter.cpp
+++ b/lib/obp60task/OBP60Formatter.cpp
@@ -192,10 +192,10 @@ FormattedData formatValue(GwApi::BoatValue *value, CommonData &commondata){
             rawvalue = value->value;
         }
         else {
-            course = 2.53 + float(random(0, 10) / 100.0);
+            course = M_PI_2 + float(random(-17, 17) / 100.0); // create random course/wind values with 90° +/- 10°
             rawvalue = course;
         }
-        course = course * 57.2958;      // Unit conversion form rad to deg
+        course = course * RAD_TO_DEG;      // Unit conversion form rad to deg
 
         // Format 3 numbers with prefix zero
         snprintf(buffer,bsize,"%03.0f",course);
@@ -210,7 +210,7 @@ FormattedData formatValue(GwApi::BoatValue *value, CommonData &commondata){
             rawvalue = value->value;
         }
         else{
-            rawvalue = 4.0 + float(random(0, 40));
+            rawvalue = 4.0 + float(random(-30, 40) / 10.0); // create random speed values from [1..8] m/s
             speed = rawvalue;
         }
         if (String(speedFormat) == "km/h"){
@@ -244,7 +244,7 @@ FormattedData formatValue(GwApi::BoatValue *value, CommonData &commondata){
             rawvalue = value->value;
         }
         else {
-            rawvalue = 4.0 + float(random(0, 40));
+            rawvalue = 4.0 + float(random(0, 40) / 10.0); // create random wind speed values from [4..8] m/s
             speed = rawvalue;
         }
         if (String(windspeedFormat) == "km/h"){
@@ -429,7 +429,7 @@ FormattedData formatValue(GwApi::BoatValue *value, CommonData &commondata){
             rawvalue = value->value;
         }
         else {
-            rawvalue = 18.0 + float(random(0, 100)) / 10.0;
+            rawvalue = 18.0 + float(random(0, 100)) / 10.0; // create random depth values from [18..28] metres
             depth = rawvalue;
         }
         if(String(lengthFormat) == "ft"){

--- a/lib/obp60task/OBP60Formatter.cpp
+++ b/lib/obp60task/OBP60Formatter.cpp
@@ -877,4 +877,21 @@ FormattedData formatValue(GwApi::BoatValue *value, CommonData &commondata){
     return result;
 }
 
+// Helper method for conversion of boat data values from SI to user defined format
+double convertValue(const double &value, const String &format, CommonData &commondata)
+{
+    std::unique_ptr<GwApi::BoatValue> tmpBValue; // Temp variable to get converted data value from <OBP60Formatter::formatValue>
+    double result; // data value converted to user defined target data format
+
+    // prepare dummy BoatValue structure for use in <formatValue>
+    tmpBValue = std::unique_ptr<GwApi::BoatValue>(new GwApi::BoatValue("dummy")); // we don't need boat value name for pure value conversion
+    tmpBValue->setFormat(format);
+    tmpBValue->valid = true;
+    tmpBValue->value = value;
+
+    result = formatValue(tmpBValue.get(), commondata).cvalue; // get value (converted)
+
+    return result;
+}
+
 #endif

--- a/lib/obp60task/OBPDataOperations.cpp
+++ b/lib/obp60task/OBPDataOperations.cpp
@@ -259,44 +259,6 @@ bool WindUtils::calcWinds(const double* awaVal, const double* awsVal,
     }
 }
 
-/* // we don't need this -> AWD is calculated in calcTwdSA
-// Calc AWD from existing AWA and HDT/HDM
-bool WindUtils::calcATWD(const double* waVal, const double* hdtVal, const double* hdmVal, const double* varVal, const double* cogVal, const double* sogVal, double* wdVal)
-{
-    double wd, hdt;
-    GwApi::BoatValue* calBVal; // temp variable just for data calibration
-    bool isCalculated = false;
-
-    if (*waVal == DBL_MAX) {
-        return false;
-    }
-
-    if (*hdtVal != DBL_MAX) {
-        hdt = *hdtVal; // Use HDT if available
-    } else {
-        hdt = calcHDT(hdmVal, varVal, cogVal, sogVal);
-    }
-
-    if (hdt != DBL_MAX) {
-        wd = *waVal + hdt;
-        wd = to2PI(wd);
-        isCalculated = true;
-    }
-
-    // Calibrate AWD/TWD if required
-    calBVal = new GwApi::BoatValue("AWD"); // temporary solution for calibration of history buffer values
-    calBVal->value = wd;
-    calBVal->setFormat(awdBVal->getFormat());
-    calBVal->valid = true;
-    calibrationData.calibrateInstance(calBVal, logger); // Check if boat data value is to be calibrated
-    *wdVal = calBVal->value;
-
-    delete calBVal;
-    calBVal = nullptr;
-
-    return isCalculated;
-} */
-
 // Calculate true wind data and add to obp60task boat data list
 bool WindUtils::addWinds()
 {

--- a/lib/obp60task/OBPDataOperations.h
+++ b/lib/obp60task/OBPDataOperations.h
@@ -68,19 +68,20 @@ public:
 
 class WindUtils {
 private:
-    GwApi::BoatValue *twdBVal, *twsBVal, *twaBVal;
-    GwApi::BoatValue *awaBVal, *awsBVal, *cogBVal, *stwBVal, *sogBVal, *hdtBVal, *hdmBVal, *varBVal;
+    GwApi::BoatValue *twaBVal, *twsBVal, *twdBVal;
+    GwApi::BoatValue *awaBVal, *awsBVal, *awdBVal, *cogBVal, *stwBVal, *sogBVal, *hdtBVal, *hdmBVal, *varBVal;
     static constexpr double DBL_MAX = std::numeric_limits<double>::max();
     GwLog* logger;
 
 public:
     WindUtils(BoatValueList* boatValues, GwLog* log)
         : logger(log) {
-        twdBVal = boatValues->findValueOrCreate("TWD");
-        twsBVal = boatValues->findValueOrCreate("TWS");
         twaBVal = boatValues->findValueOrCreate("TWA");
+        twsBVal = boatValues->findValueOrCreate("TWS");
+        twdBVal = boatValues->findValueOrCreate("TWD");
         awaBVal = boatValues->findValueOrCreate("AWA");
         awsBVal = boatValues->findValueOrCreate("AWS");
+        awdBVal = boatValues->findValueOrCreate("AWD");
         cogBVal = boatValues->findValueOrCreate("COG");
         stwBVal = boatValues->findValueOrCreate("STW");
         sogBVal = boatValues->findValueOrCreate("SOG");
@@ -100,11 +101,11 @@ public:
         double* phi, double* r);
     void calcTwdSA(const double* AWA, const double* AWS,
         const double* CTW, const double* STW, const double* HDT,
-        double* TWD, double* TWS, double* TWA);
+        double* TWD, double* TWS, double* TWA, double* AWD);
     static double calcHDT(const double* hdmVal, const double* varVal, const double* cogVal, const double* sogVal);
-    bool calcTrueWind(const double* awaVal, const double* awsVal,
+    bool calcWinds(const double* awaVal, const double* awsVal,
         const double* cogVal, const double* stwVal, const double* sogVal, const double* hdtVal,
-        const double* hdmVal, const double* varVal, double* twdVal, double* twsVal, double* twaVal);
-//    bool addTrueWind(GwApi* api, BoatValueList* boatValues, GwLog *log);
-    bool addTrueWind();
+        const double* hdmVal, const double* varVal, double* twdVal, double* twsVal, double* twaVal, double* awdVal);
+    bool calcATWD(const double* waVal, const double* hdtVal, const double* hdmVal, const double* varVal, const double* cogVal, const double* sogVal, double* wdVal);
+    bool addWinds();
 };

--- a/lib/obp60task/OBPDataOperations.h
+++ b/lib/obp60task/OBPDataOperations.h
@@ -3,9 +3,6 @@
 #include "OBPRingBuffer.h"
 #include "obp60task.h"
 #include <map>
-#include <memory>
-#include <limits>
-#include <cmath>
 
 class HstryBuf {
 private:
@@ -46,16 +43,18 @@ private:
         {"AWA", {1000, 10000, -M_PI, M_PI, "formatWind"}},
         {"AWD", {1000, 10000, 0.0, M_TWOPI, "formatCourse"}},
         {"AWS", {1000, 1000, 0.0, 65.0, "formatKnots"}},
-        {"DBS", {1000, 100, 0.0, 650, "formatDepth"}},
-        {"DBT", {1000, 100, 0.0, 650, "formatDepth"}},
-        {"DPT", {1000, 100, 0.0, 650, "formatDepth"}},
-        {"HDT", {1000, 10000, 0.0, M_TWOPI, "formatCourse"}},
+        {"COG", {1000, 10000, 0.0, M_TWOPI, "formatCourse"}},
+        {"DBS", {1000, 100, 0.0, 650.0, "formatDepth"}},
+        {"DBT", {1000, 100, 0.0, 650.0, "formatDepth"}},
+        {"DPT", {1000, 100, 0.0, 650.0, "formatDepth"}},
         {"HDM", {1000, 10000, 0.0, M_TWOPI, "formatCourse"}},
+        {"HDT", {1000, 10000, 0.0, M_TWOPI, "formatCourse"}},
+        {"ROT", {1000, 10000, -M_PI / 180.0 * 99.0, M_PI / 180.0 * 99.0, "formatRot"}}, // min/max is -/+ 99 degrees for rotational angle
+        {"SOG", {1000, 1000, 0.0, 65.0, "formatKnots"}},
+        {"STW", {1000, 1000, 0.0, 65.0, "formatKnots"}},
         {"TWA", {1000, 10000, -M_PI, M_PI, "formatWind"}},
         {"TWD", {1000, 10000, 0.0, M_TWOPI, "formatCourse"}},
         {"TWS", {1000, 1000, 0.0, 65.0, "formatKnots"}},
-        {"SOG", {1000, 1000, 0.0, 65.0, "formatKnots"}},
-        {"STW", {1000, 1000, 0.0, 65.0, "formatKnots"}},
         {"WTemp", {1000, 100, 0.0, 650.0, "kelvinToC"}}
     };
 
@@ -106,6 +105,5 @@ public:
     bool calcWinds(const double* awaVal, const double* awsVal,
         const double* cogVal, const double* stwVal, const double* sogVal, const double* hdtVal,
         const double* hdmVal, const double* varVal, double* twdVal, double* twsVal, double* twaVal, double* awdVal);
-    bool calcATWD(const double* waVal, const double* hdtVal, const double* hdmVal, const double* varVal, const double* cogVal, const double* sogVal, double* wdVal);
     bool addWinds();
 };

--- a/lib/obp60task/OBPDataOperations.h
+++ b/lib/obp60task/OBPDataOperations.h
@@ -39,9 +39,9 @@ private:
         String format;
     };
 
-    // Define buffer parameters for each boat data type
+    // Define buffer parameters for supported boat data type
     std::map<String, HistoryParams> bufferParams = {
-        {"AWA", {1000, 10000, -M_PI, M_PI, "formatWind"}},
+        {"AWA", {1000, 10000, 0.0, M_TWOPI, "formatWind"}},
         {"AWD", {1000, 10000, 0.0, M_TWOPI, "formatCourse"}},
         {"AWS", {1000, 1000, 0.0, 65.0, "formatKnots"}},
         {"COG", {1000, 10000, 0.0, M_TWOPI, "formatCourse"}},
@@ -50,13 +50,13 @@ private:
         {"DPT", {1000, 100, 0.0, 650.0, "formatDepth"}},
         {"HDM", {1000, 10000, 0.0, M_TWOPI, "formatCourse"}},
         {"HDT", {1000, 10000, 0.0, M_TWOPI, "formatCourse"}},
-        {"ROT", {1000, 10000, -M_PI / 180.0 * 99.0, M_PI / 180.0 * 99.0, "formatRot"}}, // min/max is -/+ 99 degrees for rotational angle
+        {"ROT", {1000, 10000, -M_PI / 180.0 * 99.0, M_PI / 180.0 * 99.0, "formatRot"}}, // min/max is -/+ 99 degrees for "rate of turn"
         {"SOG", {1000, 1000, 0.0, 65.0, "formatKnots"}},
         {"STW", {1000, 1000, 0.0, 65.0, "formatKnots"}},
-        {"TWA", {1000, 10000, -M_PI, M_PI, "formatWind"}},
+        {"TWA", {1000, 10000, 0.0, M_TWOPI, "formatWind"}},
         {"TWD", {1000, 10000, 0.0, M_TWOPI, "formatCourse"}},
         {"TWS", {1000, 1000, 0.0, 65.0, "formatKnots"}},
-        {"WTemp", {1000, 100, 0.0, 650.0, "kelvinToC"}}
+        {"WTemp", {1000, 100, 233.0, 650.0, "kelvinToC"}} // [-50..376] °C
     };
 
 public:

--- a/lib/obp60task/OBPDataOperations.h
+++ b/lib/obp60task/OBPDataOperations.h
@@ -2,6 +2,7 @@
 #pragma once
 #include "OBPRingBuffer.h"
 #include "obp60task.h"
+#include "Pagedata.h"
 #include <map>
 
 class HstryBuf {
@@ -19,7 +20,7 @@ public:
     HstryBuf(const String& name, int size, BoatValueList* boatValues, GwLog* log);
     void init(const String& format, int updFreq, int mltplr, double minVal, double maxVal);
     void add(double value);
-    void handle(bool useSimuData);
+    void handle(bool useSimuData, CommonData& common);
 };
 
 class HstryBuffers {
@@ -61,7 +62,7 @@ private:
 public:
     HstryBuffers(int size, BoatValueList* boatValues, GwLog* log);
     void addBuffer(const String& name);
-    void handleHstryBufs(bool useSimuData);
+    void handleHstryBufs(bool useSimuData, CommonData& common);
     RingBuffer<uint16_t>* getBuffer(const String& name);
 };
 

--- a/lib/obp60task/OBPcharts.h
+++ b/lib/obp60task/OBPcharts.h
@@ -26,7 +26,7 @@ protected:
     int top = 44; // chart gap at top of display (25 lines for standard gap + 19 lines for axis labels)
     int bottom = 25; // chart gap at bottom of display to keep space for status line
     int hGap = 11; // gap between 2 horizontal charts; actual gap is 2x <gap>
-    int vGap = 20; // gap between 2 vertical charts; actual gap is 2x <gap>
+    int vGap = 17; // gap between 2 vertical charts; actual gap is 2x <gap>
     int dWidth; // Display width
     int dHeight; // Display height
     int timAxis, valAxis; // size of time and value chart axis

--- a/lib/obp60task/OBPcharts.h
+++ b/lib/obp60task/OBPcharts.h
@@ -22,6 +22,8 @@ protected:
     uint16_t fgColor; // color code for any screen writing
     uint16_t bgColor; // color code for screen background
     bool useSimuData; // flag to indicate if simulation data is active
+    String tempFormat; // user defined format for temperature
+    double zeroValue; // "0" SI value for temperature
 
     int top = 44; // chart gap at top of display (25 lines for standard gap + 19 lines for axis labels)
     int bottom = 25; // chart gap at bottom of display to keep space for status line
@@ -50,30 +52,35 @@ protected:
     size_t currIdx; // Current index in TWD history buffer
     size_t lastIdx; // Last index of TWD history buffer
     size_t lastAddedIdx = 0; // Last index of TWD history buffer when new data was added
+    int numNoData; // Counter for multiple invalid data values in a row
     bool bufDataValid = false; // Flag to indicate if buffer data is valid
     int oldChrtIntv = 0; // remember recent user selection of data interval
 
+    double chrtPrevVal; // Last data value in chart area
+    int x, y; // x and y coordinates for drawing
+    int prevX, prevY; // Last x and y coordinates for drawing
+
     void drawChrt(int8_t chrtIntv, GwApi::BoatValue& currValue); // Draw chart line
-    double getRng(double center, size_t amount); // Calculate range between chart center and edges
-    void calcChrtBorders(double& rngMid, double& rngMin, double& rngMax, double& rng); // Calculate chart points for value axis and return range between <min> and <max>
+    void calcChrtBorders(double& rngMin, double& rngMid, double& rngMax, double& rng); // Calculate chart points for value axis and return range between <min> and <max>
     void drawChrtTimeAxis(int8_t chrtIntv); // Draw time axis of chart, value and lines
     void drawChrtValAxis(); // Draw value axis of chart, value and lines
     void prntCurrValue(GwApi::BoatValue& currValue); // Add current boat data value to chart
+    double getAngleRng(double center, size_t amount); // Calculate range between chart center and edges
 
 public:
     // Define default chart range for each boat data type
-    static std::map<String, double> dfltChartRng;
+    static std::map<String, double> dfltChrtRng;
 
     Chart(RingBuffer<T>& dataBuf, char chrtDir, int8_t chrtSz, double dfltRng, CommonData& common, bool useSimuData); // Chart object of data chart
     ~Chart();
-    void showChrt(int8_t chrtIntv, GwApi::BoatValue currValue, bool showCurrValue); // Perform all actions to draw chart
+    void showChrt(GwApi::BoatValue currValue, int8_t chrtIntv, bool showCurrValue); // Perform all actions to draw chart
 };
 
 template <typename T>
-std::map<String, double> Chart<T>::dfltChartRng = {
+std::map<String, double> Chart<T>::dfltChrtRng = {
     { "formatWind", 60.0 * DEG_TO_RAD }, // default course range 60 degrees
     { "formatCourse", 60.0 * DEG_TO_RAD }, // default course range 60 degrees
     { "formatKnots", 5.1 }, // default speed range in m/s
-    { "formatDepth", 15 }, // default depth range in m
-    { "kelvinToC", 30 } // default temp range in °C/K
+    { "formatDepth", 15.0 }, // default depth range in m
+    { "kelvinToC", 30.0 } // default temp range in °C/K
 };

--- a/lib/obp60task/OBPcharts.h
+++ b/lib/obp60task/OBPcharts.h
@@ -6,16 +6,16 @@ struct Pos {
     int x;
     int y;
 };
+
 template <typename T> class RingBuffer;
 class GwLog;
 
-template <typename T>
-class Chart {
+template <typename T> class Chart {
 protected:
-    CommonData *commonData;
-    GwLog *logger;
+    CommonData* commonData;
+    GwLog* logger;
 
-    RingBuffer<T> &dataBuf; // Buffer to display
+    RingBuffer<T>& dataBuf; // Buffer to display
     char chrtDir; // Chart timeline direction: 'H' = horizontal, 'V' = vertical
     int8_t chrtSz; // Chart size: [0] = full size, [1] = half size left/top, [2] half size right/bottom
     double dfltRng; // Default range of chart, e.g. 30 = [0..30]
@@ -23,7 +23,6 @@ protected:
     uint16_t bgColor; // color code for screen background
     bool useSimuData; // flag to indicate if simulation data is active
 
-    // int top = 48; // display top header lines
     int top = 44; // chart gap at top of display (25 lines for standard gap + 19 lines for axis labels)
     int bottom = 25; // chart gap at bottom of display to keep space for status line
     int hGap = 11; // gap between 2 horizontal charts; actual gap is 2x <gap>
@@ -59,11 +58,22 @@ protected:
     void calcChrtBorders(double& rngMid, double& rngMin, double& rngMax, double& rng); // Calculate chart points for value axis and return range between <min> and <max>
     void drawChrtTimeAxis(int8_t chrtIntv); // Draw time axis of chart, value and lines
     void drawChrtValAxis(); // Draw value axis of chart, value and lines
-    void prntCurrValue(GwApi::BoatValue& currValue); // Add current boat data value to chart 
+    void prntCurrValue(GwApi::BoatValue& currValue); // Add current boat data value to chart
 
 public:
+    // Define default chart range for each boat data type
+    static std::map<String, double> dfltChartRng;
+
     Chart(RingBuffer<T>& dataBuf, char chrtDir, int8_t chrtSz, double dfltRng, CommonData& common, bool useSimuData); // Chart object of data chart
     ~Chart();
-    void showChrt(int8_t chrtIntv, GwApi::BoatValue currValue); // Perform all actions to draw chart
+    void showChrt(int8_t chrtIntv, GwApi::BoatValue currValue, bool showCurrValue); // Perform all actions to draw chart
+};
 
+template <typename T>
+std::map<String, double> Chart<T>::dfltChartRng = {
+    { "formatWind", 60.0 * DEG_TO_RAD }, // default course range 60 degrees
+    { "formatCourse", 60.0 * DEG_TO_RAD }, // default course range 60 degrees
+    { "formatKnots", 5.1 }, // default speed range in m/s
+    { "formatDepth", 15 }, // default depth range in m
+    { "kelvinToC", 30 } // default temp range in °C/K
 };

--- a/lib/obp60task/OBPcharts.h
+++ b/lib/obp60task/OBPcharts.h
@@ -16,19 +16,18 @@ protected:
     GwLog *logger;
 
     RingBuffer<T> &dataBuf; // Buffer to display
-    int8_t chrtDir; // Chart timeline direction: [0] = horizontal, [1] = vertical
+    char chrtDir; // Chart timeline direction: 'H' = horizontal, 'V' = vertical
     int8_t chrtSz; // Chart size: [0] = full size, [1] = half size left/top, [2] half size right/bottom
     double dfltRng; // Default range of chart, e.g. 30 = [0..30]
     uint16_t fgColor; // color code for any screen writing
     uint16_t bgColor; // color code for screen background
     bool useSimuData; // flag to indicate if simulation data is active
 
-    int top = 48; // display top header lines
-    int bottom = 22; // display bottom lines
+    // int top = 48; // display top header lines
+    int top = 44; // chart gap at top of display (25 lines for standard gap + 19 lines for axis labels)
+    int bottom = 25; // chart gap at bottom of display to keep space for status line
     int hGap = 11; // gap between 2 horizontal charts; actual gap is 2x <gap>
     int vGap = 20; // gap between 2 vertical charts; actual gap is 2x <gap>
-    int xOffset = 33; // offset for horizontal axis (time/value), because of space for left vertical axis labeling
-    int yOffset = 10; // offset for vertical axis (time/value), because of space for top horizontal axis labeling
     int dWidth; // Display width
     int dHeight; // Display height
     int timAxis, valAxis; // size of time and value chart axis
@@ -41,7 +40,7 @@ protected:
     bool recalcRngCntr = false; // Flag for re-calculation of mid value of chart for wind data types
 
     String dbName, dbFormat; // Name and format of data buffer
-    int chrtDataFmt; // Data format of chart: [0] size values; [1] degree of course or wind; [2] rotational degrees
+    char chrtDataFmt; // Data format of chart: 'S' = size values; 'D' = depth value, 'W' = degree of course or wind; 'R' rotational degrees
     double dbMIN_VAL; // Lowest possible value of buffer of type <T>
     double dbMAX_VAL; // Highest possible value of buffer of type <T>; indicates invalid value in buffer
     size_t bufSize; // History buffer size: 1.920 values for 32 min. history chart
@@ -63,7 +62,7 @@ protected:
     void prntCurrValue(GwApi::BoatValue& currValue); // Add current boat data value to chart 
 
 public:
-    Chart(RingBuffer<T>& dataBuf, int8_t chrtDir, int8_t chrtSz, double dfltRng, CommonData& common, bool useSimuData); // Chart object of data chart
+    Chart(RingBuffer<T>& dataBuf, char chrtDir, int8_t chrtSz, double dfltRng, CommonData& common, bool useSimuData); // Chart object of data chart
     ~Chart();
     void showChrt(int8_t chrtIntv, GwApi::BoatValue currValue); // Perform all actions to draw chart
 

--- a/lib/obp60task/PageOneValue.cpp
+++ b/lib/obp60task/PageOneValue.cpp
@@ -3,112 +3,254 @@
 #include "Pagedata.h"
 #include "OBP60Extensions.h"
 #include "BoatDataCalibration.h"
+#include "OBPcharts.h"
 
-class PageOneValue : public Page
-{
-    public:
-    PageOneValue(CommonData &common){
-        commonData = &common;
-        common.logger->logDebug(GwLog::LOG,"Instantiate PageOneValue");
+class PageOneValue : public Page {
+private:
+    GwLog* logger;
+
+    int width; // Screen width
+    int height; // Screen height
+
+    bool keylock = false; // Keylock
+    char pageMode = 'V'; // Page mode: 'V' for value, 'C' for chart, 'B' for both
+    int dataIntv = 1; // Update interval for wind history chart:
+                      // (1)|(2)|(3)|(4)|(8) x 240 seconds for 4, 8, 12, 16, 32 min. history chart
+
+    String lengthformat;
+    bool useSimuData;
+    bool holdValues;
+    String flashLED;
+    String backlightMode;
+
+    // Old values for hold function
+    String sValue1Old = "";
+    String unit1Old = "";
+
+    // Data buffer pointer (owned by HstryBuffers)
+    RingBuffer<uint16_t>* dataHstryBuf = nullptr;
+    std::unique_ptr<Chart<uint16_t>> dataFlChart, dataHfChart; // Chart object, full and half size
+    // Active chart and value
+    Chart<uint16_t>* dataChart = nullptr;
+
+    void showData(GwApi::BoatValue* bValue1, char size)
+    {
+        int nameXoff, nameYoff, unitXoff, unitYoff, value1Xoff, value1Yoff;
+        const GFXfont *nameFnt, *unitFnt, *valueFnt1, *valueFnt2, *valueFnt3;
+
+        if (size == 'F') { // full size data display
+            nameXoff = 0;
+            nameYoff = 0;
+            nameFnt = &Ubuntu_Bold32pt8b;
+            unitXoff = 0;
+            unitYoff = 0;
+            unitFnt = &Ubuntu_Bold20pt8b;
+            value1Xoff = 0;
+            value1Yoff = 0;
+            valueFnt1 = &Ubuntu_Bold20pt8b;
+            valueFnt2 = &Ubuntu_Bold32pt8b;
+            valueFnt3 = &DSEG7Classic_BoldItalic60pt7b;
+        } else { // half size data and chart display
+            nameXoff = 105;
+            nameYoff = -40;
+            nameFnt = &Ubuntu_Bold20pt8b;
+            unitXoff = -33;
+            unitYoff = -40;
+            unitFnt = &Ubuntu_Bold12pt8b;
+            valueFnt1 = &Ubuntu_Bold12pt8b;
+            value1Xoff = 105;
+            value1Yoff = -105;
+            valueFnt2 = &Ubuntu_Bold20pt8b;
+            valueFnt3 = &DSEG7Classic_BoldItalic30pt7b;
+        }
+
+        String name1 = xdrDelete(bValue1->getName()); // Value name
+        name1 = name1.substring(0, 6); // String length limit for value name
+        calibrationData.calibrateInstance(bValue1, logger); // Check if boat data value is to be calibrated
+        double value1 = bValue1->value; // Value as double in SI unit
+        bool valid1 = bValue1->valid; // Valid information
+        String sValue1 = formatValue(bValue1, *commonData).svalue; // Formatted value as string including unit conversion and switching decimal places
+        String unit1 = formatValue(bValue1, *commonData).unit; // Unit of value 
+
+        // Show name
+        getdisplay().setTextColor(commonData->fgcolor);
+        getdisplay().setFont(nameFnt);
+        getdisplay().setCursor(20 + nameXoff, 100 + nameYoff);
+        getdisplay().print(name1); // name
+
+        // Show unit
+        getdisplay().setFont(unitFnt);
+        getdisplay().setCursor(270 + unitXoff, 100 + unitYoff);
+        if (holdValues == false) {
+            //getdisplay().print(unit1); // Unit
+            drawTextRalign(298 + unitXoff, 100 + unitYoff, unit1); // Unit
+
+        } else {
+            // getdisplay().print(unit1Old);
+            drawTextRalign(298 + unitXoff, 100 + unitYoff, unit1Old);
+        }
+
+        // Switch font if format for any values
+        if (bValue1->getFormat() == "formatLatitude" || bValue1->getFormat() == "formatLongitude") {
+            getdisplay().setFont(valueFnt1);
+            getdisplay().setCursor(20 + value1Xoff, 180 + value1Yoff);
+        } else if (bValue1->getFormat() == "formatTime" || bValue1->getFormat() == "formatDate") {
+            getdisplay().setFont(valueFnt2);
+            getdisplay().setCursor(20 + value1Xoff, 200 + value1Yoff);
+        } else {
+            getdisplay().setFont(valueFnt3);
+            getdisplay().setCursor(20 + value1Xoff, 240 + value1Yoff);
+        }
+
+        // Show bus data
+        if (holdValues == false) {
+            getdisplay().print(sValue1); // Real value as formated string
+        } else {
+            getdisplay().print(sValue1Old); // Old value as formated string
+        }
+        if (valid1 == true) {
+            sValue1Old = sValue1; // Save the old value
+            unit1Old = unit1; // Save the old unit
+        }
     }
 
-    virtual int handleKey(int key){
-        // Code for keylock
-        if(key == 11){
+public:
+    PageOneValue(CommonData& common)
+    {
+        commonData = &common;
+        logger = commonData->logger;
+        LOG_DEBUG(GwLog::LOG, "Instantiate PageOneValue");
+
+        width = getdisplay().width(); // Screen width
+        height = getdisplay().height(); // Screen height
+
+        // Get config data
+        lengthformat = common.config->getString(common.config->lengthFormat);
+        useSimuData = common.config->getBool(common.config->useSimuData);
+        holdValues = common.config->getBool(common.config->holdvalues);
+        flashLED = common.config->getString(common.config->flashLED);
+        backlightMode = common.config->getString(common.config->backlight);
+    }
+
+    virtual void setupKeys()
+    {
+        Page::setupKeys();
+        commonData->keydata[0].label = "MODE";
+#if defined BOARD_OBP60S3
+        commonData->keydata[4].label = "ZOOM";
+#elif defined BOARD_OBP40S3
+        commonData->keydata[1].label = "ZOOM";
+#endif
+    }
+
+    // Key functions
+    virtual int handleKey(int key)
+    {
+        // Set page mode value | full chart | value/half chart
+        if (key == 1) {
+            if (pageMode == 'V') {
+                pageMode = 'C';
+            } else if (pageMode == 'C') {
+                pageMode = 'B';
+            } else {
+                pageMode = 'V';
+            }
+            return 0; // Commit the key
+        }
+
+        // Set interval for history chart update time (interval)
+#if defined BOARD_OBP60S3
+        if (key == 5) {
+#elif defined BOARD_OBP40S3
+        if (key == 2) {
+#endif
+            if (dataIntv == 1) {
+                dataIntv = 2;
+            } else if (dataIntv == 2) {
+                dataIntv = 3;
+            } else if (dataIntv == 3) {
+                dataIntv = 4;
+            } else if (dataIntv == 4) {
+                dataIntv = 8;
+            } else {
+                dataIntv = 1;
+            }
+            return 0; // Commit the key
+        }
+
+        // Keylock function
+        if (key == 11) { // Code for keylock
             commonData->keylock = !commonData->keylock;
-            return 0;                   // Commit the key
+            return 0; // Commit the key
         }
         return key;
     }
 
-    int displayPage(PageData &pageData){
-        GwConfigHandler *config = commonData->config;
-        GwLog *logger = commonData->logger;
+    virtual void displayNew(PageData& pageData)
+    {
+#ifdef BOARD_OBP60S3
+        // Clear optical warning
+        if (flashLED == "Limit Violation") {
+            setBlinkingLED(false);
+            setFlashLED(false);
+        }
+#endif
+        if (!dataFlChart) { // Create chart objects if they don't exist
+            GwApi::BoatValue* bValue1 = pageData.values[0]; // Page boat data element
+            String bValName1 = bValue1->getName(); // Value name
+            String bValFormat = bValue1->getFormat(); // Value format
 
-        // Old values for hold function
-        static String svalue1old = "";
-        static String unit1old = "";
+            dataHstryBuf = pageData.hstryBuffers->getBuffer(bValName1);
 
-        // Get config data
-        String lengthformat = config->getString(config->lengthFormat);
-        // bool simulation = config->getBool(config->useSimuData);
-        bool holdvalues = config->getBool(config->holdvalues);
-        String flashLED = config->getString(config->flashLED);
-        String backlightMode = config->getString(config->backlight);
-        
-        // Get boat values
-        GwApi::BoatValue *bvalue1 = pageData.values[0]; // First element in list (only one value by PageOneValue)
-        String name1 = xdrDelete(bvalue1->getName());   // Value name
-        name1 = name1.substring(0, 6);                  // String length limit for value name
-        calibrationData.calibrateInstance(bvalue1, logger); // Check if boat data value is to be calibrated
-        double value1 = bvalue1->value;                 // Value as double in SI unit
-        bool valid1 = bvalue1->valid;                   // Valid information
-        String svalue1 = formatValue(bvalue1, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
-        String unit1 = formatValue(bvalue1, *commonData).unit;        // Unit of value
+            dataFlChart.reset(new Chart<uint16_t>(*dataHstryBuf, 'H', 0, Chart<uint16_t>::dfltChartRng[bValFormat], *commonData, useSimuData));
+            dataHfChart.reset(new Chart<uint16_t>(*dataHstryBuf, 'H', 2, Chart<uint16_t>::dfltChartRng[bValFormat], *commonData, useSimuData));
+            LOG_DEBUG(GwLog::DEBUG, "PageOneValue: Created chart objects for %s", bValName1);
+        }
+    }
+
+    int displayPage(PageData& pageData)
+    {
+
+        LOG_DEBUG(GwLog::LOG, "Display PageOneValue");
+        GwConfigHandler* config = commonData->config;
+        GwLog* logger = commonData->logger;
+
+        // Get boat value for page
+        GwApi::BoatValue* bValue1 = pageData.values[0]; // Page boat data element
 
         // Optical warning by limit violation (unused)
-        if(String(flashLED) == "Limit Violation"){
+        if (String(flashLED) == "Limit Violation") {
             setBlinkingLED(false);
-            setFlashLED(false); 
+            setFlashLED(false);
         }
 
         // Logging boat values
-        if (bvalue1 == NULL) return PAGE_OK; // WTF why this statement?
-        LOG_DEBUG(GwLog::LOG,"Drawing at PageOneValue, %s: %f", name1.c_str(), value1);
+        if (bValue1 == NULL)
+            return PAGE_OK; // WTF why this statement?
+        LOG_DEBUG(GwLog::LOG, "Drawing at PageOneValue, %s: %f", bValue1->getName().c_str(), bValue1->value);
 
         // Draw page
         //***********************************************************
 
-        /// Set display in partial refresh mode
-        getdisplay().setPartialWindow(0, 0, getdisplay().width(), getdisplay().height()); // Set partial update
+        getdisplay().setPartialWindow(0, 0, width, height); // Set partial update
 
-        // Show name
-        getdisplay().setTextColor(commonData->fgcolor);
-        getdisplay().setFont(&Ubuntu_Bold32pt8b);
-        getdisplay().setCursor(20, 100);
-        getdisplay().print(name1);                           // Page name
+        if (pageMode == 'V') { // show only data value
+            showData(bValue1, 'F');
 
-        // Show unit
-        getdisplay().setFont(&Ubuntu_Bold20pt8b);
-        getdisplay().setCursor(270, 100);
-        if(holdvalues == false){
-            getdisplay().print(unit1);                       // Unit
-        }
-        else{
-            getdisplay().print(unit1old);
-        }
+        } else if (pageMode == 'C') { // show only data chart
+            dataFlChart->showChrt(dataIntv, *bValue1, true);
 
-        // Switch font if format for any values
-        if(bvalue1->getFormat() == "formatLatitude" || bvalue1->getFormat() == "formatLongitude"){
-            getdisplay().setFont(&Ubuntu_Bold20pt8b);
-            getdisplay().setCursor(20, 180);
-        }
-        else if(bvalue1->getFormat() == "formatTime" || bvalue1->getFormat() == "formatDate"){
-            getdisplay().setFont(&Ubuntu_Bold32pt8b);
-            getdisplay().setCursor(20, 200);
-        }
-        else{
-            getdisplay().setFont(&DSEG7Classic_BoldItalic60pt7b);
-            getdisplay().setCursor(20, 240);
-        }
-
-        // Show bus data
-        if(holdvalues == false){
-            getdisplay().print(svalue1);                                     // Real value as formated string
-        }
-        else{
-            getdisplay().print(svalue1old);                                  // Old value as formated string
-        }
-        if(valid1 == true){
-            svalue1old = svalue1;                                       // Save the old value
-            unit1old = unit1;                                           // Save the old unit
+        } else if (pageMode == 'B') { // show data value and chart
+            showData(bValue1, 'H');
+            dataHfChart->showChrt(dataIntv, *bValue1, false);
         }
 
         return PAGE_UPDATE;
     };
 };
 
-static Page* createPage(CommonData &common){
+static Page* createPage(CommonData& common)
+{
     return new PageOneValue(common);
 }
 
@@ -120,10 +262,10 @@ static Page* createPage(CommonData &common){
  * this will be number of BoatValue pointers in pageData.values
  */
 PageDescription registerPageOneValue(
-    "OneValue",     // Page name
-    createPage,     // Action
-    1,              // Number of bus values depends on selection in Web configuration
-    true            // Show display header on/off
+    "OneValue", // Page name
+    createPage, // Action
+    1, // Number of bus values depends on selection in Web configuration
+    true // Show display header on/off
 );
 
 #endif

--- a/lib/obp60task/PageWindPlot.cpp
+++ b/lib/obp60task/PageWindPlot.cpp
@@ -2,7 +2,6 @@
 
 #include "Pagedata.h"
 #include "OBP60Extensions.h"
-#include "OBPDataOperations.h"
 #include "OBPcharts.h"
 
 // ****************************************************************
@@ -77,9 +76,9 @@ public:
         commonData->keydata[0].label = "MODE";
 #if defined BOARD_OBP60S3
         commonData->keydata[1].label = "SRC";
-        commonData->keydata[4].label = "INTV";
+        commonData->keydata[4].label = "ZOOM";
 #elif defined BOARD_OBP40S3
-        commonData->keydata[1].label = "INTV";
+        commonData->keydata[1].label = "ZOOM";
 #endif
     }
 
@@ -209,14 +208,14 @@ public:
         getdisplay().setTextColor(commonData->fgcolor);
 
         if (chrtMode == 'D') {
-            wdFlChart->showChrt(dataIntv, *wdBVal);
+            wdFlChart->showChrt(dataIntv, *wdBVal, true);
 
         } else if (chrtMode == 'S') {
-            wsFlChart->showChrt(dataIntv, *wsBVal);
+            wsFlChart->showChrt(dataIntv, *wsBVal, true);
 
         } else if (chrtMode == 'B') {
-            wdHfChart->showChrt(dataIntv, *wdBVal);
-            wsHfChart->showChrt(dataIntv, *wsBVal);
+            wdHfChart->showChrt(dataIntv, *wdBVal, true);
+            wsHfChart->showChrt(dataIntv, *wsBVal, true);
         }
 
         LOG_DEBUG(GwLog::DEBUG, "PageWindPlot: page time %ldms", millis() - pageTime);

--- a/lib/obp60task/PageWindPlot.cpp
+++ b/lib/obp60task/PageWindPlot.cpp
@@ -22,7 +22,7 @@ private:
     int dataIntv = 1; // Update interval for wind history chart:
                       // (1)|(2)|(3)|(4)|(8) x 240 seconds for 4, 8, 12, 16, 32 min. history chart
     bool useSimuData;
-    //bool holdValues;
+    // bool holdValues;
     String flashLED;
     String backlightMode;
 
@@ -65,7 +65,7 @@ public:
 
         // Get config data
         useSimuData = common.config->getBool(common.config->useSimuData);
-        //holdValues = common.config->getBool(common.config->holdvalues);
+        // holdValues = common.config->getBool(common.config->holdvalues);
         flashLED = common.config->getString(common.config->flashLED);
         backlightMode = common.config->getString(common.config->backlight);
 
@@ -143,6 +143,7 @@ public:
         }
 #endif
 #ifdef BOARD_OBP40S3
+        // we can only initialize user defined wind source here, because "pageData" is not available at object instantiation
         wndSrc = commonData->config->getString("page" + String(pageData.pageNumber) + "wndsrc");
         if (wndSrc == "True wind") {
             showTruW = true;
@@ -151,8 +152,8 @@ public:
         }
         oldShowTruW = !showTruW; // Force chart update in displayPage
 #endif
-        // buffer initialization cannot be performed here, because <displayNew> is not executed at system start for default page
 
+        // buffer initialization cannot be performed here, because <displayNew> is not executed at system start for default page
         /* if (!twdFlChart) { // Create true wind charts if they don't exist
             twdHstry = pageData.hstryBuffers->getBuffer("TWD");
             twsHstry = pageData.hstryBuffers->getBuffer("TWS");
@@ -257,20 +258,20 @@ public:
 
         if (chrtMode == 'D') {
             if (wdFlChart) {
-                wdFlChart->showChrt(dataIntv, *wdBVal, true);
+                wdFlChart->showChrt(*wdBVal, dataIntv, true);
             }
 
         } else if (chrtMode == 'S') {
             if (wsFlChart) {
-                wsFlChart->showChrt(dataIntv, *wsBVal, true);
+                wsFlChart->showChrt(*wsBVal, dataIntv, true);
             }
 
         } else if (chrtMode == 'B') {
             if (wdHfChart) {
-                wdHfChart->showChrt(dataIntv, *wdBVal, true);
+                wdHfChart->showChrt(*wdBVal, dataIntv, true);
             }
             if (wsHfChart) {
-                wsHfChart->showChrt(dataIntv, *wsBVal, true);
+                wsHfChart->showChrt(*wsBVal, dataIntv, true);
             }
         }
 

--- a/lib/obp60task/PageWindPlot.cpp
+++ b/lib/obp60task/PageWindPlot.cpp
@@ -167,12 +167,13 @@ public:
                 LOG_DEBUG(GwLog::DEBUG, "PageWindPlot: Creating true wind charts");                
                 auto* twdHstry = pageData.hstryManager->getBuffer("TWD");
                 auto* twsHstry = pageData.hstryManager->getBuffer("TWS");
-                twdFlChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*twdHstry, 1, 0, dfltRngWd, *commonData, useSimuData));
-                twsFlChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*twsHstry, 0, 0, dfltRngWs, *commonData, useSimuData));
-                twdHfChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*twdHstry, 1, 1, dfltRngWd, *commonData, useSimuData));
-                twsHfChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*twsHstry, 1, 2, dfltRngWs, *commonData, useSimuData));
-                // twdHfChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*twdHstry, 0, 1, dfltRngWd, *commonData, useSimuData));
-                // twsHfChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*twsHstry, 0, 2, dfltRngWs, *commonData, useSimuData));
+
+                twdFlChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*twdHstry, 'V', 0, dfltRngWd, *commonData, useSimuData));
+                twsFlChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*twsHstry, 'H', 0, dfltRngWs, *commonData, useSimuData));
+                twdHfChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*twdHstry, 'V', 1, dfltRngWd, *commonData, useSimuData));
+                twsHfChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*twsHstry, 'V', 2, dfltRngWs, *commonData, useSimuData));
+                // twdHfChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*twdHstry, 'H', 1, dfltRngWd, *commonData, useSimuData));
+                // twsHfChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*twsHstry, 'H', 2, dfltRngWs, *commonData, useSimuData));
                 // LOG_DEBUG(GwLog::DEBUG, "PageWindPlot: twdHstry: %p, twsHstry: %p", (void*)twdHstry, (void*)twsHstry);
             }
 
@@ -181,10 +182,10 @@ public:
                 auto* awdHstry = pageData.hstryManager->getBuffer("AWD");
                 auto* awsHstry = pageData.hstryManager->getBuffer("AWS");
 
-                awdFlChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*awdHstry, 1, 0, dfltRngWd, *commonData, useSimuData));
-                awsFlChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*awsHstry, 0, 0, dfltRngWs, *commonData, useSimuData));
-                awdHfChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*awdHstry, 1, 1, dfltRngWd, *commonData, useSimuData));
-                awsHfChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*awsHstry, 1, 2, dfltRngWs, *commonData, useSimuData));
+                awdFlChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*awdHstry, 'V', 0, dfltRngWd, *commonData, useSimuData));
+                awsFlChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*awsHstry, 'H', 0, dfltRngWs, *commonData, useSimuData));
+                awdHfChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*awdHstry, 'V', 1, dfltRngWd, *commonData, useSimuData));
+                awsHfChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*awsHstry, 'V', 2, dfltRngWs, *commonData, useSimuData));
             }
             
             // Switch active charts based on showTruW

--- a/lib/obp60task/PageWindPlot.cpp
+++ b/lib/obp60task/PageWindPlot.cpp
@@ -2,6 +2,7 @@
 
 #include "Pagedata.h"
 #include "OBP60Extensions.h"
+#include "OBPDataOperations.h"
 #include "OBPcharts.h"
 
 // ****************************************************************
@@ -163,12 +164,9 @@ public:
         if (showTruW != oldShowTruW) {
             if (!twdFlChart) { // Create true wind charts if they don't exist
 
-                LOG_DEBUG(GwLog::DEBUG, "PageWindPlot: Creating true wind charts");
-                auto* twdHstry = pageData.boatHstry->hstryBufList.twdHstry;
-                auto* twsHstry = pageData.boatHstry->hstryBufList.twsHstry;
-                // LOG_DEBUG(GwLog::DEBUG,"History Buffer addresses PageWindPlot: twdBuf: %p, twsBuf: %p", (void*)pageData.boatHstry->hstryBufList.twdHstry,
-                //     (void*)pageData.boatHstry->hstryBufList.twsHstry);
-
+                LOG_DEBUG(GwLog::DEBUG, "PageWindPlot: Creating true wind charts");                
+                auto* twdHstry = pageData.hstryManager->getBuffer("TWD");
+                auto* twsHstry = pageData.hstryManager->getBuffer("TWS");
                 twdFlChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*twdHstry, 1, 0, dfltRngWd, *commonData, useSimuData));
                 twsFlChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*twsHstry, 0, 0, dfltRngWs, *commonData, useSimuData));
                 twdHfChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*twdHstry, 1, 1, dfltRngWd, *commonData, useSimuData));
@@ -180,8 +178,8 @@ public:
 
             if (!awdFlChart) { // Create apparent wind charts if they don't exist
                 LOG_DEBUG(GwLog::DEBUG, "PageWindPlot: Creating apparent wind charts");
-                auto* awdHstry = pageData.boatHstry->hstryBufList.awdHstry;
-                auto* awsHstry = pageData.boatHstry->hstryBufList.awsHstry;
+                auto* awdHstry = pageData.hstryManager->getBuffer("AWD");
+                auto* awsHstry = pageData.hstryManager->getBuffer("AWS");
 
                 awdFlChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*awdHstry, 1, 0, dfltRngWd, *commonData, useSimuData));
                 awsFlChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*awsHstry, 0, 0, dfltRngWs, *commonData, useSimuData));
@@ -191,15 +189,15 @@ public:
             
             // Switch active charts based on showTruW
             if (showTruW) {
-                wdHstry = pageData.boatHstry->hstryBufList.twdHstry;
-                wsHstry = pageData.boatHstry->hstryBufList.twsHstry;
+                wdHstry = pageData.hstryManager->getBuffer("TWD");
+                wsHstry = pageData.hstryManager->getBuffer("TWS");
                 wdFlChart = twdFlChart.get();
                 wsFlChart = twsFlChart.get();
                 wdHfChart = twdHfChart.get();
                 wsHfChart = twsHfChart.get();
             } else {
-                wdHstry = pageData.boatHstry->hstryBufList.awdHstry;
-                wsHstry = pageData.boatHstry->hstryBufList.awsHstry;
+                wdHstry = pageData.hstryManager->getBuffer("AWD");
+                wsHstry = pageData.hstryManager->getBuffer("AWS");
                 wdFlChart = awdFlChart.get();
                 wsFlChart = awsFlChart.get();
                 wdHfChart = awdHfChart.get();

--- a/lib/obp60task/Pagedata.h
+++ b/lib/obp60task/Pagedata.h
@@ -204,3 +204,6 @@ typedef struct{
 
 // Formatter for boat values
 FormattedData formatValue(GwApi::BoatValue *value, CommonData &commondata);
+
+// Helper method for conversion of any data value from SI to user defined format (defined in OBP60Formatter)
+double convertValue(const double &value, const String &format, CommonData &commondata);

--- a/lib/obp60task/Pagedata.h
+++ b/lib/obp60task/Pagedata.h
@@ -16,7 +16,7 @@ typedef struct{
   uint8_t pageNumber; // page number in sequence of visible pages
   //the values will always contain the user defined values first
   ValueList values;
-  HstryManager* hstryManager;
+  HstryBuffers* hstryBuffers; // list of all boat history buffers
 } PageData;
 
 // Sensor data structure (only for extended sensors, not for NMEA bus sensors)

--- a/lib/obp60task/Pagedata.h
+++ b/lib/obp60task/Pagedata.h
@@ -4,11 +4,12 @@
 #include <functional>
 #include <vector>
 #include "LedSpiTask.h"
-#include "OBPDataOperations.h"
 
 #define MAX_PAGE_NUMBER 10    // Max number of pages for show data
 
 typedef std::vector<GwApi::BoatValue *> ValueList;
+
+class HstryBuffers;
 
 typedef struct{
   GwApi *api;

--- a/lib/obp60task/Pagedata.h
+++ b/lib/obp60task/Pagedata.h
@@ -16,7 +16,7 @@ typedef struct{
   uint8_t pageNumber; // page number in sequence of visible pages
   //the values will always contain the user defined values first
   ValueList values;
-  HstryBuf* boatHstry;
+  HstryManager* hstryManager;
 } PageData;
 
 // Sensor data structure (only for extended sensors, not for NMEA bus sensors)

--- a/lib/obp60task/obp60task.cpp
+++ b/lib/obp60task/obp60task.cpp
@@ -815,7 +815,7 @@ void OBP60Task(GwApi *api){
                     trueWind.addWinds();
                 }
                 // Handle history buffers for certain boat data for windplot page and other usage
-                 hstryBufList.handleHstryBufs(useSimuData);
+                 hstryBufList.handleHstryBufs(useSimuData, commonData);
 
                 // Clear display
                 // getdisplay().fillRect(0, 0, getdisplay().width(), getdisplay().height(), commonData.bgcolor);

--- a/lib/obp60task/obp60task.cpp
+++ b/lib/obp60task/obp60task.cpp
@@ -812,7 +812,7 @@ void OBP60Task(GwApi *api){
                 api->getStatus(commonData.status);
 
                 if (calcTrueWnds) {
-                    trueWind.addTrueWind();
+                    trueWind.addWinds();
                 }
                 // Handle history buffers for certain boat data for windplot page and other usage
                  hstryBufList.handleHstryBufs(useSimuData);


### PR DESCRIPTION
Making boat data history buffer working for basically any boat data type;
adjusted chart plot code enabling it to add graphical charts to more OBP pages and for multiple boat data types;
extended PageOneValue to show graphical charts for boat data;
optimized PageWindPlot code;
added helper functions for data conversion to OBP60Formatter