### PR TITLE
Graphical charts v3 + PageOneValue/PageTwoValues with chart option + updated PageWindPlot

### DIFF
--- a/lib/obp60task/OBP60Extensions.cpp
+++ b/lib/obp60task/OBP60Extensions.cpp
@@ -434,7 +434,7 @@ void drawTextRalign(int16_t x, int16_t y, String text) {
     int16_t x1, y1;
     uint16_t w, h;
     getdisplay().getTextBounds(text, 0, 150, &x1, &y1, &w, &h);
-    getdisplay().setCursor(x - w, y);
+    getdisplay().setCursor(x - w - 1, y); // '-1' required since some strings wrap around w/o it
     getdisplay().print(text);
 }
 

--- a/lib/obp60task/OBP60Formatter.cpp
+++ b/lib/obp60task/OBP60Formatter.cpp
@@ -192,10 +192,10 @@ FormattedData formatValue(GwApi::BoatValue *value, CommonData &commondata){
             rawvalue = value->value;
         }
         else {
-            course = 2.53 + float(random(0, 10) / 100.0);
+            course = M_PI_2 + float(random(-17, 17) / 100.0); // create random course/wind values with 90° +/- 10°
             rawvalue = course;
         }
-        course = course * 57.2958;      // Unit conversion form rad to deg
+        course = course * RAD_TO_DEG;      // Unit conversion form rad to deg
 
         // Format 3 numbers with prefix zero
         snprintf(buffer,bsize,"%03.0f",course);
@@ -210,7 +210,7 @@ FormattedData formatValue(GwApi::BoatValue *value, CommonData &commondata){
             rawvalue = value->value;
         }
         else{
-            rawvalue = 4.0 + float(random(0, 40));
+            rawvalue = 4.0 + float(random(-30, 40) / 10.0); // create random speed values from [1..8] m/s
             speed = rawvalue;
         }
         if (String(speedFormat) == "km/h"){
@@ -244,7 +244,7 @@ FormattedData formatValue(GwApi::BoatValue *value, CommonData &commondata){
             rawvalue = value->value;
         }
         else {
-            rawvalue = 4.0 + float(random(0, 40));
+            rawvalue = 4.0 + float(random(0, 40) / 10.0); // create random wind speed values from [4..8] m/s
             speed = rawvalue;
         }
         if (String(windspeedFormat) == "km/h"){
@@ -429,7 +429,7 @@ FormattedData formatValue(GwApi::BoatValue *value, CommonData &commondata){
             rawvalue = value->value;
         }
         else {
-            rawvalue = 18.0 + float(random(0, 100)) / 10.0;
+            rawvalue = 18.0 + float(random(0, 100)) / 10.0; // create random depth values from [18..28] metres
             depth = rawvalue;
         }
         if(String(lengthFormat) == "ft"){

--- a/lib/obp60task/OBP60Formatter.cpp
+++ b/lib/obp60task/OBP60Formatter.cpp
@@ -878,19 +878,26 @@ FormattedData formatValue(GwApi::BoatValue *value, CommonData &commondata){
 }
 
 // Helper method for conversion of boat data values from SI to user defined format
-double convertValue(const double &value, const String &format, CommonData &commondata)
+double convertValue(const double &value, const String &name, const String &format, CommonData &commondata)
 {
     std::unique_ptr<GwApi::BoatValue> tmpBValue; // Temp variable to get converted data value from <OBP60Formatter::formatValue>
     double result; // data value converted to user defined target data format
 
-    // prepare dummy BoatValue structure for use in <formatValue>
-    tmpBValue = std::unique_ptr<GwApi::BoatValue>(new GwApi::BoatValue("dummy")); // we don't need boat value name for pure value conversion
+    // prepare temporary BoatValue structure for use in <formatValue>
+    tmpBValue = std::unique_ptr<GwApi::BoatValue>(new GwApi::BoatValue(name)); // we don't need boat value name for pure value conversion
     tmpBValue->setFormat(format);
     tmpBValue->valid = true;
     tmpBValue->value = value;
 
     result = formatValue(tmpBValue.get(), commondata).cvalue; // get value (converted)
+    return result;
+}
 
+double convertValue(const double &value, const String &format, CommonData &commondata)
+{
+    double result; // data value converted to user defined target data format
+
+    result = convertValue(value, "dummy", format, commondata);
     return result;
 }
 

--- a/lib/obp60task/OBP60Formatter.cpp
+++ b/lib/obp60task/OBP60Formatter.cpp
@@ -877,4 +877,21 @@ FormattedData formatValue(GwApi::BoatValue *value, CommonData &commondata){
     return result;
 }
 
+// Helper method for conversion of boat data values from SI to user defined format
+double convertValue(const double &value, const String &format, CommonData &commondata)
+{
+    std::unique_ptr<GwApi::BoatValue> tmpBValue; // Temp variable to get converted data value from <OBP60Formatter::formatValue>
+    double result; // data value converted to user defined target data format
+
+    // prepare dummy BoatValue structure for use in <formatValue>
+    tmpBValue = std::unique_ptr<GwApi::BoatValue>(new GwApi::BoatValue("dummy")); // we don't need boat value name for pure value conversion
+    tmpBValue->setFormat(format);
+    tmpBValue->valid = true;
+    tmpBValue->value = value;
+
+    result = formatValue(tmpBValue.get(), commondata).cvalue; // get value (converted)
+
+    return result;
+}
+
 #endif

--- a/lib/obp60task/OBPDataOperations.cpp
+++ b/lib/obp60task/OBPDataOperations.cpp
@@ -259,44 +259,6 @@ bool WindUtils::calcWinds(const double* awaVal, const double* awsVal,
     }
 }
 
-/* // we don't need this -> AWD is calculated in calcTwdSA
-// Calc AWD from existing AWA and HDT/HDM
-bool WindUtils::calcATWD(const double* waVal, const double* hdtVal, const double* hdmVal, const double* varVal, const double* cogVal, const double* sogVal, double* wdVal)
-{
-    double wd, hdt;
-    GwApi::BoatValue* calBVal; // temp variable just for data calibration
-    bool isCalculated = false;
-
-    if (*waVal == DBL_MAX) {
-        return false;
-    }
-
-    if (*hdtVal != DBL_MAX) {
-        hdt = *hdtVal; // Use HDT if available
-    } else {
-        hdt = calcHDT(hdmVal, varVal, cogVal, sogVal);
-    }
-
-    if (hdt != DBL_MAX) {
-        wd = *waVal + hdt;
-        wd = to2PI(wd);
-        isCalculated = true;
-    }
-
-    // Calibrate AWD/TWD if required
-    calBVal = new GwApi::BoatValue("AWD"); // temporary solution for calibration of history buffer values
-    calBVal->value = wd;
-    calBVal->setFormat(awdBVal->getFormat());
-    calBVal->valid = true;
-    calibrationData.calibrateInstance(calBVal, logger); // Check if boat data value is to be calibrated
-    *wdVal = calBVal->value;
-
-    delete calBVal;
-    calBVal = nullptr;
-
-    return isCalculated;
-} */
-
 // Calculate true wind data and add to obp60task boat data list
 bool WindUtils::addWinds()
 {

--- a/lib/obp60task/OBPDataOperations.h
+++ b/lib/obp60task/OBPDataOperations.h
@@ -68,19 +68,20 @@ public:
 
 class WindUtils {
 private:
-    GwApi::BoatValue *twdBVal, *twsBVal, *twaBVal;
-    GwApi::BoatValue *awaBVal, *awsBVal, *cogBVal, *stwBVal, *sogBVal, *hdtBVal, *hdmBVal, *varBVal;
+    GwApi::BoatValue *twaBVal, *twsBVal, *twdBVal;
+    GwApi::BoatValue *awaBVal, *awsBVal, *awdBVal, *cogBVal, *stwBVal, *sogBVal, *hdtBVal, *hdmBVal, *varBVal;
     static constexpr double DBL_MAX = std::numeric_limits<double>::max();
     GwLog* logger;
 
 public:
     WindUtils(BoatValueList* boatValues, GwLog* log)
         : logger(log) {
-        twdBVal = boatValues->findValueOrCreate("TWD");
-        twsBVal = boatValues->findValueOrCreate("TWS");
         twaBVal = boatValues->findValueOrCreate("TWA");
+        twsBVal = boatValues->findValueOrCreate("TWS");
+        twdBVal = boatValues->findValueOrCreate("TWD");
         awaBVal = boatValues->findValueOrCreate("AWA");
         awsBVal = boatValues->findValueOrCreate("AWS");
+        awdBVal = boatValues->findValueOrCreate("AWD");
         cogBVal = boatValues->findValueOrCreate("COG");
         stwBVal = boatValues->findValueOrCreate("STW");
         sogBVal = boatValues->findValueOrCreate("SOG");
@@ -100,11 +101,11 @@ public:
         double* phi, double* r);
     void calcTwdSA(const double* AWA, const double* AWS,
         const double* CTW, const double* STW, const double* HDT,
-        double* TWD, double* TWS, double* TWA);
+        double* TWD, double* TWS, double* TWA, double* AWD);
     static double calcHDT(const double* hdmVal, const double* varVal, const double* cogVal, const double* sogVal);
-    bool calcTrueWind(const double* awaVal, const double* awsVal,
+    bool calcWinds(const double* awaVal, const double* awsVal,
         const double* cogVal, const double* stwVal, const double* sogVal, const double* hdtVal,
-        const double* hdmVal, const double* varVal, double* twdVal, double* twsVal, double* twaVal);
-//    bool addTrueWind(GwApi* api, BoatValueList* boatValues, GwLog *log);
-    bool addTrueWind();
+        const double* hdmVal, const double* varVal, double* twdVal, double* twsVal, double* twaVal, double* awdVal);
+    bool calcATWD(const double* waVal, const double* hdtVal, const double* hdmVal, const double* varVal, const double* cogVal, const double* sogVal, double* wdVal);
+    bool addWinds();
 };

--- a/lib/obp60task/OBPDataOperations.h
+++ b/lib/obp60task/OBPDataOperations.h
@@ -3,9 +3,6 @@
 #include "OBPRingBuffer.h"
 #include "obp60task.h"
 #include <map>
-#include <memory>
-#include <limits>
-#include <cmath>
 
 class HstryBuf {
 private:
@@ -46,16 +43,18 @@ private:
         {"AWA", {1000, 10000, -M_PI, M_PI, "formatWind"}},
         {"AWD", {1000, 10000, 0.0, M_TWOPI, "formatCourse"}},
         {"AWS", {1000, 1000, 0.0, 65.0, "formatKnots"}},
-        {"DBS", {1000, 100, 0.0, 650, "formatDepth"}},
-        {"DBT", {1000, 100, 0.0, 650, "formatDepth"}},
-        {"DPT", {1000, 100, 0.0, 650, "formatDepth"}},
-        {"HDT", {1000, 10000, 0.0, M_TWOPI, "formatCourse"}},
+        {"COG", {1000, 10000, 0.0, M_TWOPI, "formatCourse"}},
+        {"DBS", {1000, 100, 0.0, 650.0, "formatDepth"}},
+        {"DBT", {1000, 100, 0.0, 650.0, "formatDepth"}},
+        {"DPT", {1000, 100, 0.0, 650.0, "formatDepth"}},
         {"HDM", {1000, 10000, 0.0, M_TWOPI, "formatCourse"}},
+        {"HDT", {1000, 10000, 0.0, M_TWOPI, "formatCourse"}},
+        {"ROT", {1000, 10000, -M_PI / 180.0 * 99.0, M_PI / 180.0 * 99.0, "formatRot"}}, // min/max is -/+ 99 degrees for rotational angle
+        {"SOG", {1000, 1000, 0.0, 65.0, "formatKnots"}},
+        {"STW", {1000, 1000, 0.0, 65.0, "formatKnots"}},
         {"TWA", {1000, 10000, -M_PI, M_PI, "formatWind"}},
         {"TWD", {1000, 10000, 0.0, M_TWOPI, "formatCourse"}},
         {"TWS", {1000, 1000, 0.0, 65.0, "formatKnots"}},
-        {"SOG", {1000, 1000, 0.0, 65.0, "formatKnots"}},
-        {"STW", {1000, 1000, 0.0, 65.0, "formatKnots"}},
         {"WTemp", {1000, 100, 0.0, 650.0, "kelvinToC"}}
     };
 
@@ -106,6 +105,5 @@ public:
     bool calcWinds(const double* awaVal, const double* awsVal,
         const double* cogVal, const double* stwVal, const double* sogVal, const double* hdtVal,
         const double* hdmVal, const double* varVal, double* twdVal, double* twsVal, double* twaVal, double* awdVal);
-    bool calcATWD(const double* waVal, const double* hdtVal, const double* hdmVal, const double* varVal, const double* cogVal, const double* sogVal, double* wdVal);
     bool addWinds();
 };

--- a/lib/obp60task/OBPDataOperations.h
+++ b/lib/obp60task/OBPDataOperations.h
@@ -39,9 +39,9 @@ private:
         String format;
     };
 
-    // Define buffer parameters for each boat data type
+    // Define buffer parameters for supported boat data type
     std::map<String, HistoryParams> bufferParams = {
-        {"AWA", {1000, 10000, -M_PI, M_PI, "formatWind"}},
+        {"AWA", {1000, 10000, 0.0, M_TWOPI, "formatWind"}},
         {"AWD", {1000, 10000, 0.0, M_TWOPI, "formatCourse"}},
         {"AWS", {1000, 1000, 0.0, 65.0, "formatKnots"}},
         {"COG", {1000, 10000, 0.0, M_TWOPI, "formatCourse"}},
@@ -50,13 +50,13 @@ private:
         {"DPT", {1000, 100, 0.0, 650.0, "formatDepth"}},
         {"HDM", {1000, 10000, 0.0, M_TWOPI, "formatCourse"}},
         {"HDT", {1000, 10000, 0.0, M_TWOPI, "formatCourse"}},
-        {"ROT", {1000, 10000, -M_PI / 180.0 * 99.0, M_PI / 180.0 * 99.0, "formatRot"}}, // min/max is -/+ 99 degrees for rotational angle
+        {"ROT", {1000, 10000, -M_PI / 180.0 * 99.0, M_PI / 180.0 * 99.0, "formatRot"}}, // min/max is -/+ 99 degrees for "rate of turn"
         {"SOG", {1000, 1000, 0.0, 65.0, "formatKnots"}},
         {"STW", {1000, 1000, 0.0, 65.0, "formatKnots"}},
-        {"TWA", {1000, 10000, -M_PI, M_PI, "formatWind"}},
+        {"TWA", {1000, 10000, 0.0, M_TWOPI, "formatWind"}},
         {"TWD", {1000, 10000, 0.0, M_TWOPI, "formatCourse"}},
         {"TWS", {1000, 1000, 0.0, 65.0, "formatKnots"}},
-        {"WTemp", {1000, 100, 0.0, 650.0, "kelvinToC"}}
+        {"WTemp", {1000, 100, 233.0, 650.0, "kelvinToC"}} // [-50..376] °C
     };
 
 public:

--- a/lib/obp60task/OBPDataOperations.h
+++ b/lib/obp60task/OBPDataOperations.h
@@ -2,6 +2,7 @@
 #pragma once
 #include "OBPRingBuffer.h"
 #include "obp60task.h"
+#include "Pagedata.h"
 #include <map>
 
 class HstryBuf {
@@ -19,7 +20,7 @@ public:
     HstryBuf(const String& name, int size, BoatValueList* boatValues, GwLog* log);
     void init(const String& format, int updFreq, int mltplr, double minVal, double maxVal);
     void add(double value);
-    void handle(bool useSimuData);
+    void handle(bool useSimuData, CommonData& common);
 };
 
 class HstryBuffers {
@@ -61,7 +62,7 @@ private:
 public:
     HstryBuffers(int size, BoatValueList* boatValues, GwLog* log);
     void addBuffer(const String& name);
-    void handleHstryBufs(bool useSimuData);
+    void handleHstryBufs(bool useSimuData, CommonData& common);
     RingBuffer<uint16_t>* getBuffer(const String& name);
 };
 

--- a/lib/obp60task/OBPDataOperations.h
+++ b/lib/obp60task/OBPDataOperations.h
@@ -1,8 +1,8 @@
 // Function lib for history buffer handling, true wind calculation, and other operations on boat data
 #pragma once
 #include "OBPRingBuffer.h"
-#include "obp60task.h"
 #include "Pagedata.h"
+#include "obp60task.h"
 #include <map>
 
 class HstryBuf {
@@ -11,8 +11,8 @@ private:
     String boatDataName;
     double hstryMin;
     double hstryMax;
-    GwApi::BoatValue *boatValue;
-    GwLog *logger;
+    GwApi::BoatValue* boatValue;
+    GwLog* logger;
 
     friend class HstryBuffers;
 
@@ -32,31 +32,32 @@ private:
     GwApi::BoatValue *awaBVal, *hdtBVal, *hdmBVal, *varBVal, *cogBVal, *sogBVal, *awdBVal; // boat values for true wind calculation
 
     struct HistoryParams {
-        int hstryUpdFreq;
-        int mltplr;
-        double bufferMinVal;
-        double bufferMaxVal;
-        String format;
+        int hstryUpdFreq; // update frequency of history buffer (documentation only)
+        int mltplr; // specifies actual value precision being storable:
+                    // [10000: 0 - 6.5535 | 1000: 0 - 65.535 | 100: 0 - 650.35 | 10: 0 - 6503.5
+        double bufferMinVal; // minimum valid data value
+        double bufferMaxVal; // maximum valid data value
+        String format; // format of data type
     };
 
     // Define buffer parameters for supported boat data type
     std::map<String, HistoryParams> bufferParams = {
-        {"AWA", {1000, 10000, 0.0, M_TWOPI, "formatWind"}},
-        {"AWD", {1000, 10000, 0.0, M_TWOPI, "formatCourse"}},
-        {"AWS", {1000, 1000, 0.0, 65.0, "formatKnots"}},
-        {"COG", {1000, 10000, 0.0, M_TWOPI, "formatCourse"}},
-        {"DBS", {1000, 100, 0.0, 650.0, "formatDepth"}},
-        {"DBT", {1000, 100, 0.0, 650.0, "formatDepth"}},
-        {"DPT", {1000, 100, 0.0, 650.0, "formatDepth"}},
-        {"HDM", {1000, 10000, 0.0, M_TWOPI, "formatCourse"}},
-        {"HDT", {1000, 10000, 0.0, M_TWOPI, "formatCourse"}},
-        {"ROT", {1000, 10000, -M_PI / 180.0 * 99.0, M_PI / 180.0 * 99.0, "formatRot"}}, // min/max is -/+ 99 degrees for "rate of turn"
-        {"SOG", {1000, 1000, 0.0, 65.0, "formatKnots"}},
-        {"STW", {1000, 1000, 0.0, 65.0, "formatKnots"}},
-        {"TWA", {1000, 10000, 0.0, M_TWOPI, "formatWind"}},
-        {"TWD", {1000, 10000, 0.0, M_TWOPI, "formatCourse"}},
-        {"TWS", {1000, 1000, 0.0, 65.0, "formatKnots"}},
-        {"WTemp", {1000, 100, 233.0, 650.0, "kelvinToC"}} // [-50..376] °C
+        { "AWA", { 1000, 10000, 0.0, M_TWOPI, "formatWind" } },
+        { "AWD", { 1000, 10000, 0.0, M_TWOPI, "formatCourse" } },
+        { "AWS", { 1000, 1000, 0.0, 65.0, "formatKnots" } },
+        { "COG", { 1000, 10000, 0.0, M_TWOPI, "formatCourse" } },
+        { "DBS", { 1000, 100, 0.0, 650.0, "formatDepth" } },
+        { "DBT", { 1000, 100, 0.0, 650.0, "formatDepth" } },
+        { "DPT", { 1000, 100, 0.0, 650.0, "formatDepth" } },
+        { "HDM", { 1000, 10000, 0.0, M_TWOPI, "formatCourse" } },
+        { "HDT", { 1000, 10000, 0.0, M_TWOPI, "formatCourse" } },
+        { "ROT", { 1000, 10000, -M_PI / 180.0 * 99.0, M_PI / 180.0 * 99.0, "formatRot" } }, // min/max is -/+ 99 degrees for "rate of turn"
+        { "SOG", { 1000, 1000, 0.0, 65.0, "formatKnots" } },
+        { "STW", { 1000, 1000, 0.0, 65.0, "formatKnots" } },
+        { "TWA", { 1000, 10000, 0.0, M_TWOPI, "formatWind" } },
+        { "TWD", { 1000, 10000, 0.0, M_TWOPI, "formatCourse" } },
+        { "TWS", { 1000, 1000, 0.0, 65.0, "formatKnots" } },
+        { "WTemp", { 1000, 100, 233.0, 650.0, "kelvinToC" } } // [-50..376] °C
     };
 
 public:
@@ -75,7 +76,8 @@ private:
 
 public:
     WindUtils(BoatValueList* boatValues, GwLog* log)
-        : logger(log) {
+        : logger(log)
+    {
         twaBVal = boatValues->findValueOrCreate("TWA");
         twsBVal = boatValues->findValueOrCreate("TWS");
         twdBVal = boatValues->findValueOrCreate("TWD");

--- a/lib/obp60task/OBPcharts.cpp
+++ b/lib/obp60task/OBPcharts.cpp
@@ -1,6 +1,6 @@
 // Function lib for display of boat data in various chart formats
 #include "OBPcharts.h"
-#include "OBP60Extensions.h"
+// #include "OBP60Extensions.h"
 #include "OBPDataOperations.h"
 #include "OBPRingBuffer.h"
 
@@ -25,18 +25,6 @@ Chart<T>::Chart(RingBuffer<T>& dataBuf, char chrtDir, int8_t chrtSz, double dflt
     fgColor = commonData->fgcolor;
     bgColor = commonData->bgcolor;
 
-    // we need "0" value for any user defined temperature format
-    tempFormat = commonData->config->getString(commonData->config->tempFormat); // [K|°C|°F]
-    if (tempFormat == "K") {
-        zeroValue = 0.0;
-    } else if (tempFormat == "C") {
-        zeroValue = 273.15;
-    } else if (tempFormat == "F") {
-        zeroValue = 255.37;
-    }
-    // LOG_DEBUG(GwLog::DEBUG, "Chart-init: fgColor: %d, bgColor: %d, tempFormat: %s, zeroValue: %.1f, &commonData: %p", fgColor, bgColor, tempFormat, zeroValue, commonData);
-
-    // LOG_DEBUG(GwLog::DEBUG, "Chart Init: Chart::dataBuf: %p, passed dataBuf: %p", (void*)&this->dataBuf, (void*)&dataBuf);
     dWidth = getdisplay().width();
     dHeight = getdisplay().height();
 
@@ -46,18 +34,18 @@ Chart<T>::Chart(RingBuffer<T>& dataBuf, char chrtDir, int8_t chrtSz, double dflt
         switch (chrtSz) {
         case 0:
             valAxis = dHeight - top - bottom;
-            cStart = { 0, top - 1 };
+            cRoot = { 0, top - 1 };
             break;
         case 1:
             valAxis = (dHeight - top - bottom) / 2 - hGap;
-            cStart = { 0, top - 1 };
+            cRoot = { 0, top - 1 };
             break;
         case 2:
             valAxis = (dHeight - top - bottom) / 2 - hGap;
-            cStart = { 0, top + (valAxis + hGap) + hGap - 1 };
+            cRoot = { 0, top + (valAxis + hGap) + hGap - 1 };
             break;
         default:
-            LOG_DEBUG(GwLog::ERROR, "displayChart: wrong init parameter");
+            LOG_DEBUG(GwLog::ERROR, "obp60:Chart %s: wrong init parameter", dataBuf.getName());
             return;
         }
 
@@ -67,22 +55,22 @@ Chart<T>::Chart(RingBuffer<T>& dataBuf, char chrtDir, int8_t chrtSz, double dflt
         switch (chrtSz) {
         case 0:
             valAxis = dWidth - 1;
-            cStart = { 0, top - 1 };
+            cRoot = { 0, top - 1 };
             break;
         case 1:
             valAxis = dWidth / 2 - vGap;
-            cStart = { 0, top - 1 };
+            cRoot = { 0, top - 1 };
             break;
         case 2:
             valAxis = dWidth / 2 - vGap;
-            cStart = { dWidth / 2 + vGap - 1, top - 1 };
+            cRoot = { dWidth / 2 + vGap - 1, top - 1 };
             break;
         default:
-            LOG_DEBUG(GwLog::ERROR, "displayChart: wrong init parameter");
+            LOG_DEBUG(GwLog::ERROR, "obp60:Chart %s: wrong init parameter", dataBuf.getName());
             return;
         }
     } else {
-        LOG_DEBUG(GwLog::ERROR, "displayChart: wrong init parameter");
+        LOG_DEBUG(GwLog::ERROR, "obp60:Chart %s: wrong init parameter", dataBuf.getName());
         return;
     }
 
@@ -91,34 +79,55 @@ Chart<T>::Chart(RingBuffer<T>& dataBuf, char chrtDir, int8_t chrtSz, double dflt
     dbMAX_VAL = dataBuf.getMaxVal();
     bufSize = dataBuf.getCapacity();
 
+    // Initialize chart data format; shorter version of standard format indicator
     if (dbFormat == "formatCourse" || dbFormat == "formatWind" || dbFormat == "formatRot") {
-
-        if (dbFormat == "formatRot") {
-            chrtDataFmt = 'R'; // Chart is showing data of rotational <degree> format
-        } else {
-            chrtDataFmt = 'W'; // Chart is showing data of course / wind <degree> format
-        }
-        rngStep = M_TWOPI / 360.0 * 10.0; // +/-10 degrees on each end of chrtMid; we are calculating with SI values
-
+        chrtDataFmt = 'W'; // Chart is showing data of course / wind <degree> format
+    } else if (dbFormat == "formatRot") {
+        chrtDataFmt = 'R'; // Chart is showing data of rotational <degree> format
+    } else if (dbFormat == "formatKnots") {
+        chrtDataFmt = 'S'; // Chart is showing data of speed or windspeed format
+    } else if (dbFormat == "formatDepth") {
+        chrtDataFmt = 'D'; // Chart ist showing data of <depth> format
+    } else if (dbFormat == "kelvinToC") {
+        chrtDataFmt = 'T'; // Chart ist showing data of <temp> format
     } else {
-        if (dbFormat == "formatDepth") {
-            chrtDataFmt = 'D'; // Chart ist showing data of <depth> format
-        } else if (dbFormat == "kelvinToC") {
-            chrtDataFmt = 'T'; // Chart ist showing data of <temp> format
-        } else {
-            chrtDataFmt = 'S'; // Chart is showing any other data format
-        }
-        rngStep = 10.0; // +/- 10 for all other values (eg. m/s, m, K, mBar)
+        chrtDataFmt = 'O'; // Chart is showing any other data format
     }
 
-    chrtMin = dbMIN_VAL;
-    chrtMax = dbMAX_VAL;
-    chrtMid = dbMAX_VAL;
+    // "0" value is the same for any data format but for user defined temperature format
+    zeroValue = 0.0;
+    if (chrtDataFmt == 'T') {
+        tempFormat = commonData->config->getString(commonData->config->tempFormat); // [K|°C|°F]
+        if (tempFormat == "K") {
+            zeroValue = 0.0;
+        } else if (tempFormat == "C") {
+            zeroValue = 273.15;
+        } else if (tempFormat == "F") {
+            zeroValue = 255.37;
+        }
+    }
+
+    // Read default range and range step for this chart type
+    if (dfltChrtDta.count(dbFormat)) {
+        dfltRng = dfltChrtDta[dbFormat].range;
+        rngStep = dfltChrtDta[dbFormat].step;
+    } else {
+        dfltRng = 15.0;
+        rngStep = 5.0;
+    }
+
+    //chrtMin = dbMIN_VAL;
+    //chrtMax = dbMAX_VAL;
+    //chrtMid = dbMAX_VAL;
+    // Initialize chart range values
+    chrtMin = zeroValue;
+    chrtMax = chrtMin + dfltRng;
+    chrtMid = (chrtMin + chrtMax) / 2;
     chrtRng = dfltRng;
     recalcRngCntr = true; // initialize <chrtMid> and chart borders on first screen call
 
-    LOG_DEBUG(GwLog::DEBUG, "Chart Init: dWidth: %d, dHeight: %d, timAxis: %d, valAxis: %d, cStart {x,y}: %d, %d, dbname: %s, rngStep: %.4f, chrtDataFmt: %c",
-        dWidth, dHeight, timAxis, valAxis, cStart.x, cStart.y, dbName, rngStep, chrtDataFmt);
+    LOG_DEBUG(GwLog::DEBUG, "Chart Init: dWidth: %d, dHeight: %d, timAxis: %d, valAxis: %d, cRoot {x,y}: %d, %d, dbname: %s, rngStep: %.4f, chrtDataFmt: %c",
+        dWidth, dHeight, timAxis, valAxis, cRoot.x, cRoot.y, dbName, rngStep, chrtDataFmt);
 };
 
 template <typename T>
@@ -129,67 +138,34 @@ Chart<T>::~Chart()
 // Perform all actions to draw chart
 // Parameters: <chrtIntv> chart time interval, <currValue> current boat data value to be printed, <showCurrValue> current boat data shall be shown yes/no
 template <typename T>
-void Chart<T>::showChrt(GwApi::BoatValue currValue, int8_t chrtIntv, bool showCurrValue)
+void Chart<T>::showChrt(GwApi::BoatValue currValue, int8_t& chrtIntv, const bool showCurrValue)
 {
     drawChrt(chrtIntv, currValue);
     drawChrtTimeAxis(chrtIntv);
     drawChrtValAxis();
 
-    if (bufDataValid) {
-        if (showCurrValue) {
-            // uses BoatValue temp variable <currValue> to format latest buffer value
-            // doesn't work unfortunately when 'simulation data' is active, because OBP60Formatter generates own simulation values in that case
-            currValue.value = dataBuf.getLast();
-            currValue.valid = currValue.value != dbMAX_VAL;
-            Chart<T>::prntCurrValue(currValue);
-        }
+    if (!bufDataValid) { // No valid data available
+        prntNoValidData();
+        return;
+    }
 
-    } else { // No valid data available -> print message
-        getdisplay().setFont(&Ubuntu_Bold10pt8b);
-
-        int pX, pY;
-        if (chrtDir == 'H') {
-            pX = cStart.x + (timAxis / 2);
-            pY = cStart.y + (valAxis / 2) - 10;
-        } else {
-            pX = cStart.x + (valAxis / 2);
-            pY = cStart.y + (timAxis / 2) - 10;
-        }
-
-        getdisplay().fillRect(pX - 37, pY - 10, 78, 24, bgColor); // Clear area for message
-        drawTextCenter(pX, pY, "No data");
-        LOG_DEBUG(GwLog::LOG, "Page chart: No valid data available");
+    if (showCurrValue) { // shows latest value from history buffer; usually this should be the most current one
+        currValue.value = dataBuf.getLast();
+        currValue.valid = currValue.value != dbMAX_VAL;
+        Chart<T>::prntCurrValue(currValue);
     }
 }
 
 // draw chart
 template <typename T>
-void Chart<T>::drawChrt(int8_t chrtIntv, GwApi::BoatValue& currValue)
+void Chart<T>::drawChrt(int8_t& chrtIntv, GwApi::BoatValue& currValue)
 {
     double chrtVal; // Current data value
     double chrtScl; // Scale for data values in pixels per value
 
     int x, y; // x and y coordinates for drawing
 
-    // Identify buffer size and buffer start position for chart
-    count = dataBuf.getCurrentSize();
-    currIdx = dataBuf.getLastIdx();
-    numAddedBufVals = (currIdx - lastAddedIdx + bufSize) % bufSize; // Number of values added to buffer since last display
-
-    if (chrtIntv != oldChrtIntv || count == 1) {
-        // new data interval selected by user; this is only x * 230 values instead of 240 seconds (4 minutes) per interval step
-        numBufVals = min(count, (timAxis - 60) * chrtIntv); // keep free or release 60 values on chart for plotting of new values
-        bufStart = max(0, count - numBufVals);
-        lastAddedIdx = currIdx;
-        oldChrtIntv = chrtIntv;
-
-    } else {
-        numBufVals = numBufVals + numAddedBufVals;
-        lastAddedIdx = currIdx;
-        if (count == bufSize) {
-            bufStart = max(0, bufStart - numAddedBufVals);
-        }
-    }
+    getBufStartNSize(chrtIntv);
 
     // LOG_DEBUG(GwLog::DEBUG, "PageOneValue:drawChart: min: %.1f, mid: %.1f, max: %.1f, rng: %.1f", chrtMin, chrtMid, chrtMax, chrtRng);
     calcChrtBorders(chrtMin, chrtMid, chrtMax, chrtRng);
@@ -204,7 +180,7 @@ void Chart<T>::drawChrt(int8_t chrtIntv, GwApi::BoatValue& currValue)
     } else if (!currValue.valid && !useSimuData) { // currently no valid boat data available and no simulation mode
         numNoData++;
         bufDataValid = true;
-        if (numNoData > 3) { // If more than 4 invalid values in a row, send message
+        if (numNoData > THRESHOLD_NO_DATA) { // If more than 4 invalid values in a row, send message
             bufDataValid = false;
         }
     } else {
@@ -222,23 +198,24 @@ void Chart<T>::drawChrt(int8_t chrtIntv, GwApi::BoatValue& currValue)
             } else {
 
                 if (chrtDir == 'H') { // horizontal chart
-                    x = cStart.x + i; // Position in chart area
+                    x = cRoot.x + i; // Position in chart area
 
-                    if (chrtDataFmt == 'S' or chrtDataFmt == 'T') { // speed data format -> print low values at bottom
-                        y = cStart.y + valAxis - static_cast<int>(((chrtVal - chrtMin) * chrtScl) + 0.5); // calculate chart point and round
-                    } else if (chrtDataFmt == 'D') {
-                        y = cStart.y + static_cast<int>(((chrtVal - chrtMin) * chrtScl) + 0.5); // calculate chart point and round
-                    } else { // degree type value
-                        y = cStart.y + static_cast<int>((WindUtils::to2PI(chrtVal - chrtMin) * chrtScl) + 0.5); // calculate chart point and round
+                    if (chrtDataFmt == 'S' or chrtDataFmt == 'T') { // speed or temperature data format -> print low values at bottom
+                        y = cRoot.y + valAxis - static_cast<int>(((chrtVal - chrtMin) * chrtScl) + 0.5); // calculate chart point and round
+                    } else if (chrtDataFmt == 'W' || chrtDataFmt == 'R') { // degree type value
+                        y = cRoot.y + static_cast<int>((WindUtils::to2PI(chrtVal - chrtMin) * chrtScl) + 0.5); // calculate chart point and round
+                    } else { // any other data format
+                        y = cRoot.y + static_cast<int>(((chrtVal - chrtMin) * chrtScl) + 0.5); // calculate chart point and round
                     }
 
                 } else { // vertical chart
-                    y = cStart.y + timAxis - i; // Position in chart area
+                    y = cRoot.y + timAxis - i; // Position in chart area
 
-                    if (chrtDataFmt == 'S' || chrtDataFmt == 'D' || chrtDataFmt == 'T') {
-                        x = cStart.x + static_cast<int>(((chrtVal - chrtMin) * chrtScl) + 0.5); // calculate chart point and round
-                    } else { // degree type value
-                        x = cStart.x + static_cast<int>((WindUtils::to2PI(chrtVal - chrtMin) * chrtScl) + 0.5); // calculate chart point and round
+                    // if (chrtDataFmt == 'S' || chrtDataFmt == 'D' || chrtDataFmt == 'T') {
+                    if (chrtDataFmt == 'W' || chrtDataFmt == 'R') { // degree type value
+                        x = cRoot.x + static_cast<int>((WindUtils::to2PI(chrtVal - chrtMin) * chrtScl) + 0.5); // calculate chart point and round
+                    } else {
+                        x = cRoot.x + static_cast<int>(((chrtVal - chrtMin) * chrtScl) + 0.5); // calculate chart point and round
                     }
                 }
 
@@ -261,45 +238,44 @@ void Chart<T>::drawChrt(int8_t chrtIntv, GwApi::BoatValue& currValue)
                         // LOG_DEBUG(GwLog::DEBUG, "PageWindPlot Chart: crossedBorders: %d, chrtVal: %.2f, chrtPrevVal: %.2f", crossedBorders, chrtVal, chrtPrevVal);
                         bool wrappingFromHighToLow = normCurr < normPrev; // Determine which edge we're crossing
                         if (chrtDir == 'H') {
-                            int ySplit = wrappingFromHighToLow ? (cStart.y + valAxis) : cStart.y;
-                            getdisplay().drawLine(prevX, prevY, x, ySplit, fgColor);
-                            if (x != prevX) { // line with some horizontal trend
-                                getdisplay().drawLine(prevX, prevY - 1, x, ySplit - 1, fgColor);
-                            } else {
-                                getdisplay().drawLine(prevX, prevY - 1, x - 1, ySplit, fgColor);
-                            }
-                            prevY = wrappingFromHighToLow ? cStart.y : (cStart.y + valAxis);
+                            int ySplit = wrappingFromHighToLow ? (cRoot.y + valAxis) : cRoot.y;
+                            drawBoldLine(prevX, prevY, x, ySplit);
+                            prevY = wrappingFromHighToLow ? cRoot.y : (cRoot.y + valAxis);
                         } else { // vertical chart
-                            int xSplit = wrappingFromHighToLow ? (cStart.x + valAxis) : cStart.x;
-                            getdisplay().drawLine(prevX, prevY, xSplit, y, fgColor);
-                            getdisplay().drawLine(prevX, prevY - 1, ((xSplit != prevX) ? xSplit : xSplit - 1), ((xSplit != prevX) ? y - 1 : y), fgColor);
-                            prevX = wrappingFromHighToLow ? cStart.x : (cStart.x + valAxis);
+                            int xSplit = wrappingFromHighToLow ? (cRoot.x + valAxis) : cRoot.x;
+                            drawBoldLine(prevX, prevY, xSplit, y);
+                            prevX = wrappingFromHighToLow ? cRoot.x : (cRoot.x + valAxis);
                         }
                     }
                 }
 
-                // Draw line with 2 pixels width + make sure vertical lines are drawn correctly
-                if (chrtDir == 'H' || x == prevX) { // horizontal chart & vertical line
-                    if (chrtDataFmt == 'D') {
-                        getdisplay().drawLine(x, y, x, cStart.y + valAxis, fgColor);
-                        getdisplay().drawLine(x - 1, y, x - 1, cStart.y + valAxis, fgColor);
+                if (chrtDataFmt == 'D') {
+                    if (chrtDir == 'H') { // horizontal chart
+                        drawBoldLine(x, y, x, cRoot.y + valAxis);
+                    } else { // vertical chart
+                        drawBoldLine(x, y, cRoot.x + valAxis, y);
                     }
-                    getdisplay().drawLine(prevX, prevY, x, y, fgColor);
-                    getdisplay().drawLine(prevX - 1, prevY, x - 1, y, fgColor);
-                } else if (chrtDir == 'V' || x != prevX) { // vertical chart & line with some horizontal trend -> normal state
-                    if (chrtDataFmt == 'D') {
-                        getdisplay().drawLine(x, y, cStart.x + valAxis, y, fgColor);
-                        getdisplay().drawLine(x, y - 1, cStart.x + valAxis, y - 1, fgColor);
-                    }
-                    getdisplay().drawLine(prevX, prevY, x, y, fgColor);
-                    getdisplay().drawLine(prevX, prevY - 1, x, y - 1, fgColor);
+                } else {
+                    drawBoldLine(prevX, prevY, x, y);
                 }
+
+                /*                if (chrtDir == 'H' || x == prevX) { // horizontal chart & vertical line
+                                    if (chrtDataFmt == 'D') {
+                                        drawBoldLine(x, y, x, cRoot.y + valAxis);
+                                    }
+                                    drawBoldLine(prevX, prevY, x, y);
+                                } else if (chrtDir == 'V' || x != prevX) { // vertical chart & line with some horizontal trend -> normal state
+                                    if (chrtDataFmt == 'D') {
+                                        drawBoldLine(x, y, cRoot.x + valAxis, y);
+                                    }
+                                    drawBoldLine(prevX, prevY, x, y);
+                                } */
                 chrtPrevVal = chrtVal;
                 prevX = x;
                 prevY = y;
             }
 
-            // Reaching chart area bottom end
+            // Reaching chart area top end
             if (i >= timAxis - 1) {
                 oldChrtIntv = 0; // force reset of buffer start and number of values to show in next display loop
 
@@ -309,6 +285,30 @@ void Chart<T>::drawChrt(int8_t chrtIntv, GwApi::BoatValue& currValue)
                 }
                 break;
             }
+        }
+    }
+}
+
+// Identify buffer size and buffer start position for chart
+template <typename T>
+void Chart<T>::getBufStartNSize(int8_t& chrtIntv)
+{
+    count = dataBuf.getCurrentSize();
+    currIdx = dataBuf.getLastIdx();
+    numAddedBufVals = (currIdx - lastAddedIdx + bufSize) % bufSize; // Number of values added to buffer since last display
+
+    if (chrtIntv != oldChrtIntv || count == 1) {
+        // new data interval selected by user; this is only x * 230 values instead of 240 seconds (4 minutes) per interval step
+        numBufVals = min(count, (timAxis - MIN_FREE_VALUES) * chrtIntv); // keep free or release MIN_FREE_VALUES on chart for plotting of new values
+        bufStart = max(0, count - numBufVals);
+        lastAddedIdx = currIdx;
+        oldChrtIntv = chrtIntv;
+
+    } else {
+        numBufVals = numBufVals + numAddedBufVals;
+        lastAddedIdx = currIdx;
+        if (count == bufSize) {
+            bufStart = max(0, bufStart - numAddedBufVals);
         }
     }
 }
@@ -371,94 +371,90 @@ void Chart<T>::calcChrtBorders(double& rngMin, double& rngMid, double& rngMax, d
         rngMax = WindUtils::to2PI(rngMax);
 
         rng = halfRng * 2.0;
-        LOG_DEBUG(GwLog::DEBUG, "calcChrtBorders: rngMid: %.1f°, rngMin: %.1f°, rngMax: %.1f°, diffRng: %.1f°, rng: %.1f°, rngStep: %.1f°", rngMid * RAD_TO_DEG, rngMin * RAD_TO_DEG, rngMax * RAD_TO_DEG,
-           diffRng * RAD_TO_DEG, rng * RAD_TO_DEG, rngStep * RAD_TO_DEG);
+        LOG_DEBUG(GwLog::DEBUG, "calcChrtBorders: rngMin: %.1f°, rngMid: %.1f°, rngMax: %.1f°, diffRng: %.1f°, rng: %.1f°, rngStep: %.1f°", rngMin * RAD_TO_DEG, rngMid * RAD_TO_DEG, rngMax * RAD_TO_DEG,
+            diffRng * RAD_TO_DEG, rng * RAD_TO_DEG, rngStep * RAD_TO_DEG);
 
     } else { // chart data is of any other type
 
         double oldRngMin = rngMin;
         double oldRngMax = rngMax;
 
-        // calculate low end range value
         double currMinVal = dataBuf.getMin(numBufVals);
-        LOG_DEBUG(GwLog::DEBUG, "calcChrtBorders: currMinVal: %.1f, currMaxVal: %.1f, rngMin: %.1f, rngMid: %.1f, rngMax: %.1f, rng: %.1f, rngStep: %.1f, zeroValue: %.1f, oldRngMin: %.1f, oldRngMax: %.1f, dfltRng: %.1f, dbMIN_VAL: %.1f",
-            currMinVal, dataBuf.getMax(numBufVals), rngMin, rngMid, rngMax, rng, rngStep, zeroValue, oldRngMin, oldRngMax, dfltRng, dbMIN_VAL);
-
-        if (currMinVal != dbMAX_VAL) { // current min value is valid
-
-            if (currMinVal < oldRngMin || (currMinVal > (oldRngMin + rngStep))) { // recalculate rngMin if required or increase if lowest value is higher than old rngMin
-                // rngMin = std::floor(currMinVal / rngStep) * rngStep; // align low range to lowest buffer value and nearest range interval
-                rngMin = currMinVal;
-                LOG_DEBUG(GwLog::DEBUG, "calcChrtBorders2: currMinVal: %.1f, rngMin: %.1f, oldRngMin: %.1f, zeroValue: %.1f", currMinVal, rngMin, oldRngMin, zeroValue);
-            }
-            if (rngMin > zeroValue && dbMIN_VAL <= zeroValue) { // Chart range starts at least at '0' if minimum data value allows it
-                rngMin = zeroValue;
-                LOG_DEBUG(GwLog::DEBUG, "calcChrtBorders3: currMinVal: %.1f, rngMin: %.1f, oldRngMin: %.1f, zeroValue: %.1f", currMinVal, rngMin, oldRngMin, zeroValue);
-            }
-        } // otherwise keep rngMin unchanged
-
         double currMaxVal = dataBuf.getMax(numBufVals);
-        if (currMaxVal != dbMAX_VAL) { // current max value is valid
-            if ((currMaxVal > oldRngMax) || (currMaxVal < (oldRngMax - rngStep))) { // increase rngMax if required or decrease if lowest value is lower than old rngMax
-                // rngMax = std::ceil(currMaxVal / rngStep) * rngStep;
-                rngMax = currMaxVal;
-                rngMax = std::max(rngMax, rngMin + dfltRng); // keep at least default chart range
-            }
-        } // otherwise keep rngMax unchanged
+
+        if (currMinVal == dbMAX_VAL || currMaxVal == dbMAX_VAL) {
+            return; // no valid data
+        }
+
+        // check if current chart border have to be adjusted
+        if (currMinVal < oldRngMin || (currMinVal > (oldRngMin + rngStep))) { // decrease rngMin if required or increase if lowest value is higher than old rngMin
+            rngMin = std::floor(currMinVal / rngStep) * rngStep; // align low range to lowest buffer value and nearest range interval
+        }
+        if ((currMaxVal > oldRngMax) || (currMaxVal < (oldRngMax - rngStep))) { // increase rngMax if required or decrease if lowest value is lower than old rngMax
+            rngMax = std::ceil(currMaxVal / rngStep) * rngStep;
+        }
+
+        // Chart range starts at least at '0' if minimum data value allows it
+        if (rngMin > zeroValue && dbMIN_VAL <= zeroValue) {
+            rngMin = zeroValue;
+        }
+
+        // ensure minimum chart range in user format
+        if ((rngMax - rngMin) < dfltRng) {
+            rngMax = rngMin + dfltRng;
+        }
 
         rngMid = (rngMin + rngMax) / 2.0;
         rng = rngMax - rngMin;
-        // LOG_DEBUG(GwLog::DEBUG, "calcChrtRange-end: currMinVal: %.1f, currMaxVal: %.1f, rngMin: %.1f, rngMid: %.1f, rngMax: %.1f, rng: %.1f, rngStep: %.1f, oldRngMin: %.1f, oldRngMax: %.1f, dfltRng: %.1f, numBufVals: %d",
-        //      currMinVal, currMaxVal, rngMin, rngMid, rngMax, rng, rngStep, oldRngMin, oldRngMax, dfltRng, numBufVals);
+
+        LOG_DEBUG(GwLog::DEBUG, "calcChrtRange-end: currMinVal: %.1f, currMaxVal: %.1f, rngMin: %.1f, rngMid: %.1f, rngMax: %.1f, rng: %.1f, rngStep: %.1f, zeroValue: %.1f, dbMIN_VAL: %.1f",
+            currMinVal, currMaxVal, rngMin, rngMid, rngMax, rng, rngStep, zeroValue, dbMIN_VAL);
     }
 }
 
 // chart time axis label + lines
 template <typename T>
-void Chart<T>::drawChrtTimeAxis(int8_t chrtIntv)
+void Chart<T>::drawChrtTimeAxis(int8_t& chrtIntv)
 {
-    float slots, intv, i;
+    float axSlots, intv, i;
     char sTime[6];
     int timeRng = chrtIntv * 4; // chart time interval: [1] 4 min., [2] 8 min., [3] 12 min., [4] 16 min., [8] 32 min.
 
     getdisplay().setFont(&Ubuntu_Bold8pt8b);
     getdisplay().setTextColor(fgColor);
 
-    if (chrtDir == 'H') { // horizontal chart
-        getdisplay().fillRect(0, cStart.y, dWidth, 2, fgColor);
+    axSlots = 5; // number of axis labels
+    intv = timAxis / (axSlots - 1); // minutes per chart axis interval (interval is 1 less than axSlots)
+    i = timeRng; // Chart axis label start at -32, -16, -12, ... minutes
 
-        slots = 5; // number of axis labels
-        intv = timAxis / (slots - 1); // minutes per chart axis interval (interval is 1 less than slots)
-        i = timeRng; // Chart axis label start at -32, -16, -12, ... minutes
+    if (chrtDir == 'H') { // horizontal chart
+        getdisplay().fillRect(0, cRoot.y, dWidth, 2, fgColor);
 
         for (float j = 0; j < timAxis - 1; j += intv) { // fill time axis with values but keep area free on right hand side for value label
 
             // draw text with appropriate offset
             int tOffset = j == 0 ? 13 : -4;
             snprintf(sTime, sizeof(sTime), "-%.0f", i);
-            drawTextCenter(cStart.x + j + tOffset, cStart.y - 8, sTime);
-            getdisplay().drawLine(cStart.x + j, cStart.y, cStart.x + j, cStart.y + 5, fgColor); // draw short vertical time mark
+            drawTextCenter(cRoot.x + j + tOffset, cRoot.y - 8, sTime);
+            getdisplay().drawLine(cRoot.x + j, cRoot.y, cRoot.x + j, cRoot.y + 5, fgColor); // draw short vertical time mark
 
             i -= chrtIntv;
         }
 
     } else { // vertical chart
-        slots = 5; // number of axis labels
-        intv = timAxis / (slots - 1); // minutes per chart axis interval (interval is 1 less than slots)
-        i = timeRng; // Chart axis label start at -32, -16, -12, ... minutes
 
         for (float j = intv; j < timAxis - 1; j += intv) { // don't print time label at upper and lower end of time axis
 
             i -= chrtIntv; // we start not at top chart position
             snprintf(sTime, sizeof(sTime), "-%.0f", i);
-            getdisplay().drawLine(cStart.x, cStart.y + j, cStart.x + valAxis, cStart.y + j, fgColor); // Grid line
+            getdisplay().drawLine(cRoot.x, cRoot.y + j, cRoot.x + valAxis, cRoot.y + j, fgColor); // Grid line
 
             if (chrtSz == 0) { // full size chart
-                getdisplay().fillRect(0, cStart.y + j - 9, 32, 15, bgColor); // clear small area to remove potential chart lines
-                getdisplay().setCursor((4 - strlen(sTime)) * 7, cStart.y + j + 3); // time value; print left screen; value right-formated
+                getdisplay().fillRect(0, cRoot.y + j - 9, 32, 15, bgColor); // clear small area to remove potential chart lines
+                getdisplay().setCursor((4 - strlen(sTime)) * 7, cRoot.y + j + 3); // time value; print left screen; value right-formated
                 getdisplay().printf("%s", sTime); // Range value
             } else if (chrtSz == 2) { // half size chart; right side
-                drawTextCenter(dWidth / 2, cStart.y + j, sTime); // time value; print mid screen
+                drawTextCenter(dWidth / 2, cRoot.y + j, sTime); // time value; print mid screen
             }
         }
     }
@@ -468,142 +464,75 @@ void Chart<T>::drawChrtTimeAxis(int8_t chrtIntv)
 template <typename T>
 void Chart<T>::drawChrtValAxis()
 {
-    double slots;
-    int i, intv;
-    double cVal, cChrtRng;
-    char sVal[6];
-    int sLen;
+    double axLabel;
+    double cVal;
+    // char sVal[6];
+
+    getdisplay().setTextColor(fgColor);
 
     if (chrtDir == 'H') {
 
-        // adjust value range to user defined data format
-        if (chrtDataFmt == 'T') {
-            if (tempFormat == "F") {
-                cChrtRng = chrtRng * (9 / 5);
-            } else {
-                // data steps for Kelvin and Celsius are identical and '1'
-                cChrtRng = chrtRng;
-            }
-        } else {
-            // any other data format can be converted with standard rules
-            cChrtRng = convertValue(chrtRng, dataBuf.getFormat(), *commonData);
-        }
-        if (useSimuData) {
-            // cannot use <convertValue> in this case, because that would change the range value to some random data
-            cChrtRng = chrtRng; // take SI value in this case -> need to be improved
-        }
-
-        slots = valAxis / 60.0; // number of axis labels
-        intv = static_cast<int>(round(cChrtRng / slots));
-        i = static_cast<int>(convertValue(chrtMin, dataBuf.getFormat(), *commonData) + intv + 0.5); // convert and round lower chart value end
-        LOG_DEBUG(GwLog::DEBUG, "Chart::drawChrtValAxis: chrtRng: %.2f, cChrtRng: %.2f, slots: %.2f, intv: %d, chrtMin: %.2f, chrtMid: %.2f, chrtMax: %.2f", chrtRng, cChrtRng, slots, intv, chrtMin, chrtMid, chrtMax);
-
-        if (chrtSz == 0 && chrtDataFmt != 'W') { // full size chart -> print multiple value lines
-            getdisplay().setFont(&Ubuntu_Bold12pt8b);
-
-            int loopStrt, loopEnd, loopStp;
-            if (chrtDataFmt == 'S' || chrtDataFmt == 'T') {
-                loopStrt = valAxis - 60;
-                loopEnd = 30;
-                loopStp = -60;
-            } else {
-                loopStrt = 60;
-                loopEnd = valAxis - 30;
-                loopStp = 60;
-            }
-
-            for (int j = loopStrt; (loopStp > 0) ? (j < loopEnd) : (j > loopEnd); j += loopStp) {
-                getdisplay().drawLine(cStart.x, cStart.y + j, cStart.x + timAxis, cStart.y + j, fgColor);
-
-                getdisplay().fillRect(cStart.x, cStart.y + j - 11, 42, 21, bgColor); // Clear small area to remove potential chart lines
-                String sVal = String(i);
-                getdisplay().setCursor((3 - sVal.length()) * 10, cStart.y + j + 7); // value right-formated
-                getdisplay().printf("%s", sVal); // Range value
-
-                i += intv;
-            }
-
-        } else { // half size chart or degree values -> print just edge values + middle chart line
-            LOG_DEBUG(GwLog::DEBUG, "Chart::drawChrtValAxis: chrtDataFmt: %c, chrtMin: %.2f, chrtMid: %.2f, chrtMax: %.2f", chrtDataFmt, chrtMin, chrtMid, chrtMax);
-            getdisplay().setFont(&Ubuntu_Bold10pt8b);
-
-            // cVal = (chrtDataFmt == 'D') ? chrtMin : chrtMax;
-            cVal = (chrtDataFmt == 'S' || chrtDataFmt == 'T') ? chrtMax : chrtMin;
-            cVal = convertValue(cVal, dataBuf.getFormat(), *commonData); // value (converted)
-            if (useSimuData) { // dirty fix for problem that OBP60Formatter can only be used without data simulation -> returns random values in simulation mode
-                // cVal = (chrtDataFmt == 'D') ? chrtMin : chrtMax; // no value conversion
-                cVal = (chrtDataFmt == 'S' || chrtDataFmt == 'T') ? chrtMax : chrtMin; // no value conversion
-            }
-            sLen = snprintf(sVal, sizeof(sVal), "%.0f", round(cVal));
-            getdisplay().fillRect(cStart.x, cStart.y + 2, 42, 16, bgColor); // Clear small area to remove potential chart lines
-            getdisplay().setCursor(cStart.x + ((3 - sLen) * 10), cStart.y + 16);
-            getdisplay().printf("%s", sVal); // Range low end
-
-            cVal = chrtMid;
-            cVal = convertValue(cVal, dataBuf.getFormat(), *commonData); // value (converted)
-            if (useSimuData) { // dirty fix for problem that OBP60Formatter can only be used without data simulation -> returns random values in simulation mode
-                cVal = chrtMid; // no value conversion
-            }
-            sLen = snprintf(sVal, sizeof(sVal), "%.0f", round(cVal));
-            getdisplay().fillRect(cStart.x, cStart.y + (valAxis / 2) - 9, 42, 16, bgColor); // Clear small area to remove potential chart lines
-            getdisplay().setCursor(cStart.x + ((3 - sLen) * 10), cStart.y + (valAxis / 2) + 5);
-            getdisplay().printf("%s", sVal); // Range mid value
-            getdisplay().drawLine(cStart.x + 43, cStart.y + (valAxis / 2), cStart.x + timAxis, cStart.y + (valAxis / 2), fgColor);
-
-            // cVal = (chrtDataFmt == 'D') ? chrtMax : chrtMin;
-            cVal = (chrtDataFmt == 'S' || chrtDataFmt == 'T') ? chrtMin : chrtMax;
-            cVal = convertValue(cVal, dataBuf.getFormat(), *commonData); // value (converted)
-            if (useSimuData) { // dirty fix for problem that OBP60Formatter can only be used without data simulation -> returns random values in simulation mode
-                // cVal = (chrtDataFmt == 'D') ? chrtMax : chrtMin; // no value conversion
-                cVal = (chrtDataFmt == 'S' || chrtDataFmt == 'T') ? chrtMax : chrtMin; // no value conversion
-            }
-            sLen = snprintf(sVal, sizeof(sVal), "%.0f", round(cVal));
-            getdisplay().fillRect(cStart.x, cStart.y + valAxis - 16, 42, 16, bgColor); // Clear small area to remove potential chart lines
-            getdisplay().setCursor(cStart.x + ((3 - sLen) * 10), cStart.y + valAxis - 1);
-            getdisplay().printf("%s", sVal); // Range high end
-            getdisplay().drawLine(cStart.x + 43, cStart.y + valAxis, cStart.x + timAxis, cStart.y + valAxis, fgColor);
-        }
-
+        // print buffer data name on right hand side of time axis (max. size 5 characters)
         getdisplay().setFont(&Ubuntu_Bold12pt8b);
-        drawTextRalign(cStart.x + timAxis, cStart.y - 3, dbName.substring(0, 4)); // buffer data name (max. size 4 characters)
+        drawTextRalign(cRoot.x + timAxis, cRoot.y - 3, dbName.substring(0, 5));
+
+        if (chrtSz == 0) { // full size chart
+
+            if (chrtDataFmt == 'W') {
+                prntHorizThreeValueAxisLabel(&Ubuntu_Bold12pt8b);
+                return;
+            }
+
+            // for any other data formats print multiple axis value lines on full charts
+            prntHorizMultiValueAxisLabel(&Ubuntu_Bold12pt8b);
+            return;
+
+        } else { // half size chart -> just print edge values + middle chart line
+            LOG_DEBUG(GwLog::DEBUG, "Chart::drawChrtValAxis: chrtDataFmt: %c, chrtMin: %.2f, chrtMid: %.2f, chrtMax: %.2f", chrtDataFmt, chrtMin, chrtMid, chrtMax);
+
+            prntHorizThreeValueAxisLabel(&Ubuntu_Bold10pt8b);
+            return;
+        }
 
     } else { // vertical chart
-        if (chrtSz == 0) { // full size chart -> use larger font
-            getdisplay().setFont(&Ubuntu_Bold12pt8b);
-            drawTextRalign(cStart.x + (valAxis * 0.42), cStart.y - 2, dbName.substring(0, 6)); // buffer data name (max. size 5 characters)
+        char sVal[6];
+
+        if (chrtSz == 0) { // full size chart
+            getdisplay().setFont(&Ubuntu_Bold12pt8b); // use larger font
+            drawTextRalign(cRoot.x + (valAxis * 0.42), cRoot.y - 2, dbName.substring(0, 6)); // print buffer data name (max. size 5 characters)
         } else {
-            getdisplay().setFont(&Ubuntu_Bold10pt8b);
+            getdisplay().setFont(&Ubuntu_Bold10pt8b); // use smaller font
         }
-        getdisplay().fillRect(cStart.x, cStart.y, valAxis, 2, fgColor); // top chart line
+        getdisplay().fillRect(cRoot.x, cRoot.y, valAxis, 2, fgColor); // top chart line
 
         cVal = chrtMin;
-        cVal = convertValue(cVal, dataBuf.getFormat(), *commonData);
+        cVal = convertValue(cVal, dbName, dbFormat, *commonData); // value (converted)
         if (useSimuData) { // dirty fix for problem that OBP60Formatter can only be used without data simulation -> returns random values in simulation mode
             cVal = chrtMin; // no value conversion
         }
         snprintf(sVal, sizeof(sVal), "%.0f", round(cVal));
-        getdisplay().setCursor(cStart.x, cStart.y - 2);
+        getdisplay().setCursor(cRoot.x, cRoot.y - 2);
         getdisplay().printf("%s", sVal); // Range low end
 
         cVal = chrtMid;
-        cVal = convertValue(cVal, dataBuf.getFormat(), *commonData);
+        cVal = convertValue(cVal, dbName, dbFormat, *commonData); // value (converted)
         if (useSimuData) { // dirty fix for problem that OBP60Formatter can only be used without data simulation -> returns random values in simulation mode
             cVal = chrtMid; // no value conversion
         }
         snprintf(sVal, sizeof(sVal), "%.0f", round(cVal));
-        drawTextCenter(cStart.x + (valAxis / 2), cStart.y - 9, sVal); // Range mid end
+        drawTextCenter(cRoot.x + (valAxis / 2), cRoot.y - 9, sVal); // Range mid end
 
         cVal = chrtMax;
-        cVal = convertValue(cVal, dataBuf.getFormat(), *commonData);
+        cVal = convertValue(cVal, dbName, dbFormat, *commonData); // value (converted)
         if (useSimuData) { // dirty fix for problem that OBP60Formatter can only be used without data simulation -> returns random values in simulation mode
             cVal = chrtMax; // no value conversion
         }
         snprintf(sVal, sizeof(sVal), "%.0f", round(cVal));
-        drawTextRalign(cStart.x + valAxis - 2, cStart.y - 2, sVal); // Range high end
+        drawTextRalign(cRoot.x + valAxis - 2, cRoot.y - 2, sVal); // Range high end
 
         // draw vertical grid lines for each axis label
         for (int j = 0; j <= valAxis; j += (valAxis / 2)) {
-            getdisplay().drawLine(cStart.x + j, cStart.y, cStart.x + j, cStart.y + timAxis, fgColor);
+            getdisplay().drawLine(cRoot.x + j, cRoot.y, cRoot.x + j, cRoot.y + timAxis, fgColor);
         }
     }
 }
@@ -612,8 +541,8 @@ void Chart<T>::drawChrtValAxis()
 template <typename T>
 void Chart<T>::prntCurrValue(GwApi::BoatValue& currValue)
 {
-    const int xPosVal = (chrtDir == 'H') ? cStart.x + (timAxis / 2) - 56 : cStart.x + 32;
-    const int yPosVal = (chrtDir == 'H') ? cStart.y + valAxis - 7 : cStart.y + timAxis - 7;
+    const int xPosVal = (chrtDir == 'H') ? cRoot.x + (timAxis / 2) - 56 : cRoot.x + 32;
+    const int yPosVal = (chrtDir == 'H') ? cRoot.y + valAxis - 7 : cRoot.y + timAxis - 7;
 
     FormattedData frmtDbData = formatValue(&currValue, *commonData);
     String sdbValue = frmtDbData.svalue; // value as formatted string
@@ -634,6 +563,28 @@ void Chart<T>::prntCurrValue(GwApi::BoatValue& currValue)
     getdisplay().setFont(&Ubuntu_Bold8pt8b);
     getdisplay().setCursor(xPosVal + 76, yPosVal + 0);
     getdisplay().print(dbUnit); // Unit
+}
+
+// print message for no valid data availabletemplate <typename T>
+template <typename T>
+void Chart<T>::prntNoValidData()
+{
+    int pX, pY;
+
+    getdisplay().setFont(&Ubuntu_Bold10pt8b);
+
+    if (chrtDir == 'H') {
+        pX = cRoot.x + (timAxis / 2);
+        pY = cRoot.y + (valAxis / 2) - 10;
+    } else {
+        pX = cRoot.x + (valAxis / 2);
+        pY = cRoot.y + (timAxis / 2) - 10;
+    }
+
+    getdisplay().fillRect(pX - 37, pY - 10, 78, 24, bgColor); // Clear area for message
+    drawTextCenter(pX, pY, "No data");
+
+    LOG_DEBUG(GwLog::LOG, "Page chart <%s>: No valid data available", dbName);
 }
 
 // Get maximum difference of last <amount> of dataBuf ringbuffer values to center chart; for angle data only
@@ -670,6 +621,170 @@ double Chart<T>::getAngleRng(double center, size_t amount)
     }
 
     return (maxRng != dbMIN_VAL ? maxRng : dbMAX_VAL); // Return range from <mid> to <max>
+}
+
+// print horizontal axis label with only three values: top, mid, and bottom
+template <typename T>
+void Chart<T>::prntHorizThreeValueAxisLabel(const GFXfont* font)
+{
+    double axLabel;
+    double chrtMin, chrtMid, chrtMax;
+    int xOffset, yOffset; // offset for text position of x axis label for different font sizes
+    String sVal;
+
+    if (font == &Ubuntu_Bold10pt8b) {
+        xOffset = 39;
+        yOffset = 15;
+    } else if (font == &Ubuntu_Bold12pt8b) {
+        xOffset = 51;
+        yOffset = 17;
+    }
+    getdisplay().setFont(font);
+
+    // convert & round chart bottom+top label to next range step
+    chrtMin = convertValue(this->chrtMin, dbName, dbFormat, *commonData);
+    chrtMid = convertValue(this->chrtMid, dbName, dbFormat, *commonData);
+    chrtMax = convertValue(this->chrtMax, dbName, dbFormat, *commonData);
+    chrtMin = std::round(chrtMin * 100.0) / 100.0;
+    chrtMid = std::round(chrtMid * 100.0) / 100.0;
+    chrtMax = std::round(chrtMax * 100.0) / 100.0;
+
+    // print top axis label
+    axLabel = (chrtDataFmt == 'S' || chrtDataFmt == 'T') ? chrtMax : chrtMin;
+    sVal = formatLabel(axLabel);
+    getdisplay().fillRect(cRoot.x, cRoot.y + 2, xOffset + 4, yOffset, bgColor); // Clear small area to remove potential chart lines
+    drawTextRalign(cRoot.x + xOffset, cRoot.y + yOffset, sVal); // range value
+
+    // print mid axis label
+    axLabel = chrtMid;
+    sVal = formatLabel(axLabel);
+    getdisplay().fillRect(cRoot.x, cRoot.y + (valAxis / 2) - 9, xOffset + 4, 16, bgColor); // Clear small area to remove potential chart lines
+    drawTextRalign(cRoot.x + xOffset, cRoot.y + (valAxis / 2) + 5, sVal); // range value
+    getdisplay().drawLine(cRoot.x + xOffset + 4, cRoot.y + (valAxis / 2), cRoot.x + timAxis, cRoot.y + (valAxis / 2), fgColor);
+
+    // print bottom axis label
+    axLabel = (chrtDataFmt == 'S' || chrtDataFmt == 'T') ? chrtMin : chrtMax;
+    sVal = formatLabel(axLabel);
+    getdisplay().fillRect(cRoot.x, cRoot.y + valAxis - 16, xOffset + 3, 16, bgColor); // Clear small area to remove potential chart lines
+    drawTextRalign(cRoot.x + xOffset, cRoot.y + valAxis, sVal); // range value
+    getdisplay().drawLine(cRoot.x + xOffset + 2, cRoot.y + valAxis, cRoot.x + timAxis, cRoot.y + valAxis, fgColor);
+}
+
+// print horizontal axis label with multiple axis lines
+template <typename T>
+void Chart<T>::prntHorizMultiValueAxisLabel(const GFXfont* font)
+{
+    double chrtMin, chrtMax, chrtRng;
+    double axSlots, axIntv, axLabel;
+    int xOffset; // offset for text position of x axis label for different font sizes
+    String sVal;
+
+    if (font == &Ubuntu_Bold10pt8b) {
+        xOffset = 38;
+    } else if (font == &Ubuntu_Bold12pt8b) {
+        xOffset = 50;
+    }
+    getdisplay().setFont(font);
+
+    chrtMin = convertValue(this->chrtMin, dbName, dbFormat, *commonData);
+    // chrtMin = std::floor(chrtMin / rngStep) * rngStep;
+    chrtMin = std::round(chrtMin * 100.0) / 100.0;
+    chrtMax = convertValue(this->chrtMax, dbName, dbFormat, *commonData);
+    // chrtMax = std::ceil(chrtMax / rngStep) * rngStep;
+    chrtMax = std::round(chrtMax * 100.0) / 100.0;
+    chrtRng = std::round((chrtMax - chrtMin) * 100) / 100;
+
+    axSlots = valAxis / static_cast<double>(VALAXIS_STEP); // number of axis labels (and we want to have a double calculation, no integer)
+    axIntv = chrtRng / axSlots;
+    axLabel = chrtMin + axIntv;
+    LOG_DEBUG(GwLog::DEBUG, "Chart::printHorizMultiValueAxisLabel: chrtRng: %.2f, th-chrtRng: %.2f, axSlots: %.2f, axIntv: %.2f, axLabel: %.2f, chrtMin: %.2f, chrtMid: %.2f, chrtMax: %.2f", chrtRng, this->chrtRng, axSlots, axIntv, axLabel, this->chrtMin, chrtMid, chrtMax);
+
+    int loopStrt, loopEnd, loopStp;
+    if (chrtDataFmt == 'S' || chrtDataFmt == 'T' || chrtDataFmt == 'O') {
+        // High value at top
+        loopStrt = valAxis - VALAXIS_STEP;
+        loopEnd = VALAXIS_STEP / 2;
+        loopStp = VALAXIS_STEP * -1;
+    } else {
+        // Low value at top
+        loopStrt = VALAXIS_STEP;
+        loopEnd = valAxis - (VALAXIS_STEP / 2);
+        loopStp = VALAXIS_STEP;
+    }
+
+    for (int j = loopStrt; (loopStp > 0) ? (j < loopEnd) : (j > loopEnd); j += loopStp) {
+        sVal = formatLabel(axLabel);
+        // sVal = convNformatLabel(axLabel);
+        getdisplay().fillRect(cRoot.x, cRoot.y + j - 11, xOffset + 4, 21, bgColor); // Clear small area to remove potential chart lines
+        drawTextRalign(cRoot.x + xOffset, cRoot.y + j + 7, sVal); // range value
+        getdisplay().drawLine(cRoot.x + xOffset + 3, cRoot.y + j, cRoot.x + timAxis, cRoot.y + j, fgColor);
+
+        axLabel += axIntv;
+    }
+}
+
+// Draw chart line with thickness of 2px
+template <typename T>
+void Chart<T>::drawBoldLine(int16_t x1, int16_t y1, int16_t x2, int16_t y2)
+{
+
+    int16_t dx = std::abs(x2 - x1);
+    int16_t dy = std::abs(y2 - y1);
+
+    getdisplay().drawLine(x1, y1, x2, y2, fgColor);
+
+    if (dx >= dy) { // line has horizontal tendency
+        getdisplay().drawLine(x1, y1 - 1, x2, y2 - 1, fgColor);
+    } else { // line has vertical tendency
+        getdisplay().drawLine(x1 - 1, y1, x2 - 1, y2, fgColor);
+    }
+}
+
+// Convert and format current axis label to user defined format; helper function for easier handling of OBP60Formatter
+template <typename T>
+String Chart<T>::convNformatLabel(double label)
+{
+    GwApi::BoatValue tmpBVal(dbName); // temporary boat value for string formatter
+    String sVal;
+
+    tmpBVal.setFormat(dbFormat);
+    tmpBVal.valid = true;
+    tmpBVal.value = label;
+    sVal = formatValue(&tmpBVal, *commonData).svalue; // Formatted value as string including unit conversion and switching decimal places
+    if (sVal.length() > 0 && sVal[0] == '!') {
+        sVal = sVal.substring(1); // cut leading "!" created at OBPFormatter for use with other font than 7SEG
+    }
+
+    return sVal;
+}
+
+// Format current axis label for printing w/o data format conversion (has been done earlier)
+template <typename T>
+String Chart<T>::formatLabel(const double& label)
+{
+    char sVal[11];
+
+    if (dbFormat == "formatCourse" || dbFormat == "formatWind") {
+        // Format 3 numbers with prefix zero
+        snprintf(sVal, sizeof(sVal), "%03.0f", label);
+
+    } else if (dbFormat == "formatRot") {
+        if (label > -10 && label < 10) {
+            snprintf(sVal, sizeof(sVal), "%3.2f", label);
+        } else {
+            snprintf(sVal, sizeof(sVal), "%3.0f", label);
+        }
+    }
+
+    else {
+        if (label < 10) {
+            snprintf(sVal, sizeof(sVal), "%3.1f", label);
+        } else {
+            snprintf(sVal, sizeof(sVal), "%3.0f", label);
+        }
+    }
+
+    return String(sVal);
 }
 
 // Explicitly instantiate class with required data types to avoid linker errors

--- a/lib/obp60task/OBPcharts.cpp
+++ b/lib/obp60task/OBPcharts.cpp
@@ -1,13 +1,11 @@
 // Function lib for display of boat data in various chart formats
 #include "OBPcharts.h"
-// #include "OBP60Extensions.h"
 #include "OBPDataOperations.h"
 #include "OBPRingBuffer.h"
 
 std::map<String, ChartProps> Chart::dfltChrtDta = {
     { "formatWind", { 60.0 * DEG_TO_RAD, 10.0 * DEG_TO_RAD } }, // default course range 60 degrees
     { "formatCourse", { 60.0 * DEG_TO_RAD, 10.0 * DEG_TO_RAD } }, // default course range 60 degrees
-    //{ "formatKnots", { 7.71, 2.57 } }, // default speed range in m/s
     { "formatKnots", { 7.71, 2.56 } }, // default speed range in m/s
     { "formatDepth", { 15.0, 5.0 } }, // default depth range in m
     { "kelvinToC", { 30.0, 5.0 } } // default temp range in °C/K
@@ -16,16 +14,12 @@ std::map<String, ChartProps> Chart::dfltChrtDta = {
 // --- Class Chart ---------------
 
 // Chart - object holding the actual chart, incl. data buffer and format definition
-// Parameters: <chrtDir> chart timeline direction: 'H' = horizontal, 'V' = vertical;
-//             <chrtSz> chart size: [0] = full size, [1] = half size left/top, [2] half size right/bottom;
-//             <dfltRng> default range of chart, e.g. 30 = [0..30];
+// Parameters: <dataBuf> the history data buffer for the chart
+//             <dfltRng> default range of chart, e.g. 30 = [0..30]
 //             <common> common program data; required for logger and color data
 //             <useSimuData> flag to indicate if simulation data is active
-// Chart::Chart(RingBuffer<uint16_t>& dataBuf, char chrtDir, int8_t chrtSz, double dfltRng, CommonData& common, bool useSimuData)
 Chart::Chart(RingBuffer<uint16_t>& dataBuf, double dfltRng, CommonData& common, bool useSimuData)
     : dataBuf(dataBuf)
-    //, chrtDir(chrtDir)
-    //, chrtSz(chrtSz)
     , dfltRng(dfltRng)
     , commonData(&common)
     , useSimuData(useSimuData)
@@ -37,52 +31,6 @@ Chart::Chart(RingBuffer<uint16_t>& dataBuf, double dfltRng, CommonData& common, 
     dWidth = getdisplay().width();
     dHeight = getdisplay().height();
 
-    /*    if (chrtDir == 'H') {
-            // horizontal chart timeline direction
-            timAxis = dWidth - 1;
-            switch (chrtSz) {
-            case 0:
-                valAxis = dHeight - top - bottom;
-                cRoot = { 0, top - 1 };
-                break;
-            case 1:
-                valAxis = (dHeight - top - bottom) / 2 - hGap;
-                cRoot = { 0, top - 1 };
-                break;
-            case 2:
-                valAxis = (dHeight - top - bottom) / 2 - hGap;
-                cRoot = { 0, top + (valAxis + hGap) + hGap - 1 };
-                break;
-            default:
-                LOG_DEBUG(GwLog::ERROR, "obp60:Chart %s: wrong init parameter", dataBuf.getName());
-                return;
-            }
-
-        } else if (chrtDir == 'V') {
-            // vertical chart timeline direction
-            timAxis = dHeight - top - bottom;
-            switch (chrtSz) {
-            case 0:
-                valAxis = dWidth - 1;
-                cRoot = { 0, top - 1 };
-                break;
-            case 1:
-                valAxis = dWidth / 2 - vGap;
-                cRoot = { 0, top - 1 };
-                break;
-            case 2:
-                valAxis = dWidth / 2 - vGap;
-                cRoot = { dWidth / 2 + vGap - 1, top - 1 };
-                break;
-            default:
-                LOG_DEBUG(GwLog::ERROR, "obp60:Chart %s: wrong init parameter", dataBuf.getName());
-                return;
-            }
-        } else {
-            LOG_DEBUG(GwLog::ERROR, "obp60:Chart %s: wrong init parameter", dataBuf.getName());
-            return;
-        } */
-
     dataBuf.getMetaData(dbName, dbFormat);
     dbMIN_VAL = dataBuf.getMinVal();
     dbMAX_VAL = dataBuf.getMaxVal();
@@ -90,22 +38,22 @@ Chart::Chart(RingBuffer<uint16_t>& dataBuf, double dfltRng, CommonData& common, 
 
     // Initialize chart data format; shorter version of standard format indicator
     if (dbFormat == "formatCourse" || dbFormat == "formatWind" || dbFormat == "formatRot") {
-        chrtDataFmt = 'W'; // Chart is showing data of course / wind <degree> format
+        chrtDataFmt = WIND; // Chart is showing data of course / wind <degree> format
     } else if (dbFormat == "formatRot") {
-        chrtDataFmt = 'R'; // Chart is showing data of rotational <degree> format
+        chrtDataFmt = ROTATION; // Chart is showing data of rotational <degree> format
     } else if (dbFormat == "formatKnots") {
-        chrtDataFmt = 'S'; // Chart is showing data of speed or windspeed format
+        chrtDataFmt = SPEED; // Chart is showing data of speed or windspeed format
     } else if (dbFormat == "formatDepth") {
-        chrtDataFmt = 'D'; // Chart ist showing data of <depth> format
+        chrtDataFmt = DEPTH; // Chart ist showing data of <depth> format
     } else if (dbFormat == "kelvinToC") {
-        chrtDataFmt = 'T'; // Chart ist showing data of <temp> format
+        chrtDataFmt = TEMPERATURE; // Chart ist showing data of <temp> format
     } else {
-        chrtDataFmt = 'O'; // Chart is showing any other data format
+        chrtDataFmt = OTHER; // Chart is showing any other data format
     }
 
     // "0" value is the same for any data format but for user defined temperature format
     zeroValue = 0.0;
-    if (chrtDataFmt == 'T') {
+    if (chrtDataFmt == TEMPERATURE) {
         tempFormat = commonData->config->getString(commonData->config->tempFormat); // [K|°C|°F]
         if (tempFormat == "K") {
             zeroValue = 0.0;
@@ -130,9 +78,9 @@ Chart::Chart(RingBuffer<uint16_t>& dataBuf, double dfltRng, CommonData& common, 
     chrtMax = chrtMin + dfltRng;
     chrtMid = (chrtMin + chrtMax) / 2;
     chrtRng = dfltRng;
-    recalcRngCntr = true; // initialize <chrtMid> and chart borders on first screen call
+    recalcRngMid = true; // initialize <chrtMid> and chart borders on first screen call
 
-    LOG_DEBUG(GwLog::DEBUG, "Chart Init: dWidth: %d, dHeight: %d, timAxis: %d, valAxis: %d, cRoot {x,y}: %d, %d, dbname: %s, rngStep: %.4f, chrtDataFmt: %c",
+    LOG_DEBUG(GwLog::DEBUG, "Chart Init: dWidth: %d, dHeight: %d, timAxis: %d, valAxis: %d, cRoot {x,y}: %d, %d, dbname: %s, rngStep: %.4f, chrtDataFmt: %d",
         dWidth, dHeight, timAxis, valAxis, cRoot.x, cRoot.y, dbName, rngStep, chrtDataFmt);
 };
 
@@ -144,28 +92,25 @@ Chart::~Chart()
 // Parameters: <chrtDir>:       chart timeline direction: 'H' = horizontal, 'V' = vertical
 //             <chrtSz>:        chart size: [0] = full size, [1] = half size left/top, [2] half size right/bottom
 //             <chrtIntv>:      chart timeline interval
-//             <showCurrValue>: current boat data shall be shown [true/false]
-//             <currValue>:     current boat data value to be printed
-// void Chart::showChrt(GwApi::BoatValue currValue, int8_t& chrtIntv, const bool showCurrValue)
-void Chart::showChrt(char chrtDir, int8_t chrtSz, int8_t& chrtIntv, bool showCurrValue, GwApi::BoatValue currValue)
+//             <prntName>;      print data name on horizontal half chart [true|false]
+//             <showCurrValue>: print current boat data value [true|false]
+//             <currValue>:     current boat data value; used only for test on valid data
+void Chart::showChrt(char chrtDir, int8_t chrtSz, const int8_t chrtIntv, bool prntName, bool showCurrValue, GwApi::BoatValue currValue)
 {
-    // this->chrtDir = chrtDir;
-    //  this->chrtSz = chrtSz;
-
     if (!setChartDimensions(chrtDir, chrtSz)) {
         return; // wrong chart dimension parameters
     }
 
     drawChrt(chrtDir, chrtIntv, currValue);
     drawChrtTimeAxis(chrtDir, chrtSz, chrtIntv);
-    drawChrtValAxis(chrtDir, chrtSz);
+    drawChrtValAxis(chrtDir, chrtSz, prntName);
 
     if (!bufDataValid) { // No valid data available
         prntNoValidData(chrtDir);
         return;
     }
 
-    if (showCurrValue) { // show latest value from history buffer; usually this should be the most current one
+    if (showCurrValue) { // show latest value from history buffer; this should be the most current one
         currValue.value = dataBuf.getLast();
         currValue.valid = currValue.value != dbMAX_VAL;
         prntCurrValue(chrtDir, currValue);
@@ -175,12 +120,12 @@ void Chart::showChrt(char chrtDir, int8_t chrtSz, int8_t& chrtIntv, bool showCur
 // define dimensions and start points for chart
 bool Chart::setChartDimensions(const char direction, const int8_t size)
 {
-    if ((direction != 'H' && direction != 'V') || (size < 0 || size > 2)) {
+    if ((direction != HORIZONTAL && direction != VERTICAL) || (size < 0 || size > 2)) {
         LOG_DEBUG(GwLog::ERROR, "obp60:setChartDimensions %s: wrong parameters", dataBuf.getName());
         return false;
     }
 
-    if (direction == 'H') {
+    if (direction == HORIZONTAL) {
         // horizontal chart timeline direction
         timAxis = dWidth - 1;
         switch (size) {
@@ -198,7 +143,7 @@ bool Chart::setChartDimensions(const char direction, const int8_t size)
             break;
         }
 
-    } else if (direction == 'V') {
+    } else if (direction == VERTICAL) {
         // vertical chart timeline direction
         timAxis = dHeight - top - bottom;
         switch (size) {
@@ -222,139 +167,41 @@ bool Chart::setChartDimensions(const char direction, const int8_t size)
 }
 
 // draw chart
-void Chart::drawChrt(const char chrtDir, int8_t& chrtIntv, GwApi::BoatValue& currValue)
+void Chart::drawChrt(const char chrtDir, const int8_t chrtIntv, GwApi::BoatValue& currValue)
 {
-    double chrtVal; // Current data value
-    double chrtScl; // Scale for data values in pixels per value
+    double chrtScale; // Scale for data values in pixels per value
 
-    int x, y; // x and y coordinates for drawing
-
-    getBufStartNSize(chrtIntv);
+    getBufferStartNSize(chrtIntv);
 
     // LOG_DEBUG(GwLog::DEBUG, "Chart:drawChart: min: %.1f, mid: %.1f, max: %.1f, rng: %.1f", chrtMin, chrtMid, chrtMax, chrtRng);
     calcChrtBorders(chrtMin, chrtMid, chrtMax, chrtRng);
-    LOG_DEBUG(GwLog::DEBUG, "Chart:drawChart2: min: %.1f, mid: %.1f, max: %.1f, rng: %.1f", chrtMin, chrtMid, chrtMax, chrtRng);
-
-    // Chart scale: pixels per value step
-    chrtScl = double(valAxis) / chrtRng;
+    chrtScale = double(valAxis) / chrtRng; // Chart scale: pixels per value step
+    LOG_DEBUG(GwLog::DEBUG, "Chart:drawChart: min: %.1f, mid: %.1f, max: %.1f, rng: %.1f", chrtMin, chrtMid, chrtMax, chrtRng);
 
     // Do we have valid buffer data?
     if (dataBuf.getMax() == dbMAX_VAL) { // only <MAX_VAL> values in buffer -> no valid wind data available
         bufDataValid = false;
-    } else if (!currValue.valid && !useSimuData) { // currently no valid boat data available and no simulation mode
+        return;
+
+    } else if (currValue.valid || useSimuData) { // latest boat data valid or simulation mode
+        numNoData = 0; // reset data error counter
+        bufDataValid = true;
+
+    } else { // currently no valid data
         numNoData++;
         bufDataValid = true;
-        if (numNoData > THRESHOLD_NO_DATA) { // If more than 4 invalid values in a row, send message
+
+        if (numNoData > THRESHOLD_NO_DATA) { // If more than 4 invalid values in a row, flag for invalid data
             bufDataValid = false;
-        }
-    } else {
-        numNoData = 0; // reset data error counter
-        bufDataValid = true; // At least some wind data available
-    }
-
-    // Draw wind values in chart
-    //***********************************************************************
-    if (bufDataValid) {
-        for (int i = 0; i < (numBufVals / chrtIntv); i++) {
-            chrtVal = dataBuf.get(bufStart + (i * chrtIntv)); // show the latest wind values in buffer; keep 1st value constant in a rolling buffer
-            if (chrtVal == dbMAX_VAL) {
-                chrtPrevVal = dbMAX_VAL;
-            } else {
-
-                if (chrtDir == 'H') { // horizontal chart
-                    x = cRoot.x + i; // Position in chart area
-
-                    if (chrtDataFmt == 'S' or chrtDataFmt == 'T') { // speed or temperature data format -> print low values at bottom
-                        y = cRoot.y + valAxis - static_cast<int>(((chrtVal - chrtMin) * chrtScl) + 0.5); // calculate chart point and round
-                    } else if (chrtDataFmt == 'W' || chrtDataFmt == 'R') { // degree type value
-                        y = cRoot.y + static_cast<int>((WindUtils::to2PI(chrtVal - chrtMin) * chrtScl) + 0.5); // calculate chart point and round
-                    } else { // any other data format
-                        y = cRoot.y + static_cast<int>(((chrtVal - chrtMin) * chrtScl) + 0.5); // calculate chart point and round
-                    }
-
-                } else { // vertical chart
-                    y = cRoot.y + timAxis - i; // Position in chart area
-
-                    // if (chrtDataFmt == 'S' || chrtDataFmt == 'D' || chrtDataFmt == 'T') {
-                    if (chrtDataFmt == 'W' || chrtDataFmt == 'R') { // degree type value
-                        x = cRoot.x + static_cast<int>((WindUtils::to2PI(chrtVal - chrtMin) * chrtScl) + 0.5); // calculate chart point and round
-                    } else {
-                        x = cRoot.x + static_cast<int>(((chrtVal - chrtMin) * chrtScl) + 0.5); // calculate chart point and round
-                    }
-                }
-
-                // if (i >= (numBufVals / chrtIntv) - 5) // log chart data of 1 line (adjust for test purposes)
-                //    LOG_DEBUG(GwLog::DEBUG, "PageWindPlot Chart: i: %d, chrtVal: %.2f, chrtMin: %.2f, {x,y} {%d,%d}", i, chrtVal, chrtMin, x, y);
-
-                if ((i == 0) || (chrtPrevVal == dbMAX_VAL)) {
-                    // just a dot for 1st chart point or after some invalid values
-                    prevX = x;
-                    prevY = y;
-
-                } else if (chrtDataFmt == 'W' || chrtDataFmt == 'R') {
-                    // cross borders check for degree values; shift values to [-PI..0..PI]; when crossing borders, range is 2x PI degrees
-                    double normCurr = WindUtils::to2PI(chrtVal - chrtMin);
-                    double normPrev = WindUtils::to2PI(chrtPrevVal - chrtMin);
-                    // Check if pixel positions are far apart (crossing chart boundary); happens when one value is near chrtMax and the other near chrtMin
-                    bool crossedBorders = std::abs(normCurr - normPrev) > (chrtRng / 2.0);
-
-                    if (crossedBorders) { // If current value crosses chart borders compared to previous value, split line
-                        // LOG_DEBUG(GwLog::DEBUG, "PageWindPlot Chart: crossedBorders: %d, chrtVal: %.2f, chrtPrevVal: %.2f", crossedBorders, chrtVal, chrtPrevVal);
-                        bool wrappingFromHighToLow = normCurr < normPrev; // Determine which edge we're crossing
-                        if (chrtDir == 'H') {
-                            int ySplit = wrappingFromHighToLow ? (cRoot.y + valAxis) : cRoot.y;
-                            drawBoldLine(prevX, prevY, x, ySplit);
-                            prevY = wrappingFromHighToLow ? cRoot.y : (cRoot.y + valAxis);
-                        } else { // vertical chart
-                            int xSplit = wrappingFromHighToLow ? (cRoot.x + valAxis) : cRoot.x;
-                            drawBoldLine(prevX, prevY, xSplit, y);
-                            prevX = wrappingFromHighToLow ? cRoot.x : (cRoot.x + valAxis);
-                        }
-                    }
-                }
-
-                if (chrtDataFmt == 'D') {
-                    if (chrtDir == 'H') { // horizontal chart
-                        drawBoldLine(x, y, x, cRoot.y + valAxis);
-                    } else { // vertical chart
-                        drawBoldLine(x, y, cRoot.x + valAxis, y);
-                    }
-                } else {
-                    drawBoldLine(prevX, prevY, x, y);
-                }
-
-                /*                if (chrtDir == 'H' || x == prevX) { // horizontal chart & vertical line
-                                    if (chrtDataFmt == 'D') {
-                                        drawBoldLine(x, y, x, cRoot.y + valAxis);
-                                    }
-                                    drawBoldLine(prevX, prevY, x, y);
-                                } else if (chrtDir == 'V' || x != prevX) { // vertical chart & line with some horizontal trend -> normal state
-                                    if (chrtDataFmt == 'D') {
-                                        drawBoldLine(x, y, cRoot.x + valAxis, y);
-                                    }
-                                    drawBoldLine(prevX, prevY, x, y);
-                                } */
-                chrtPrevVal = chrtVal;
-                prevX = x;
-                prevY = y;
-            }
-
-            // Reaching chart area top end
-            if (i >= timAxis - 1) {
-                oldChrtIntv = 0; // force reset of buffer start and number of values to show in next display loop
-
-                if (chrtDataFmt == 'W') { // degree of course or wind
-                    recalcRngCntr = true;
-                    LOG_DEBUG(GwLog::DEBUG, "PageWindPlot: chart end: timAxis: %d, i: %d, bufStart: %d, numBufVals: %d, recalcRngCntr: %d", timAxis, i, bufStart, numBufVals, recalcRngCntr);
-                }
-                break;
-            }
+            return;
         }
     }
+
+    drawChartLines(chrtDir, chrtIntv, chrtScale);
 }
 
 // Identify buffer size and buffer start position for chart
-void Chart::getBufStartNSize(int8_t& chrtIntv)
+void Chart::getBufferStartNSize(const int8_t chrtIntv)
 {
     count = dataBuf.getCurrentSize();
     currIdx = dataBuf.getLastIdx();
@@ -379,19 +226,24 @@ void Chart::getBufStartNSize(int8_t& chrtIntv)
 // check and adjust chart range and set range borders and range middle
 void Chart::calcChrtBorders(double& rngMin, double& rngMid, double& rngMax, double& rng)
 {
-    if (chrtDataFmt == 'W' || chrtDataFmt == 'R') {
-        // Chart data is of type 'course', 'wind' or 'rot'
+    if (chrtDataFmt == WIND || chrtDataFmt == ROTATION) {
 
-        if (chrtDataFmt == 'W') {
-            // Chart data is of type 'course' or 'wind'
+        if (chrtDataFmt == ROTATION) {
+            // if chart data is of type 'rotation', we want to have <rndMid> always to be '0'
+            rngMid = 0;
 
+        } else { // WIND: Chart data is of type 'course' or 'wind'
+
+            // initialize <rngMid> if data buffer has just been started filling
             if ((count == 1 && rngMid == 0) || rngMid == dbMAX_VAL) {
-                recalcRngCntr = true; // initialize <rngMid>
+                recalcRngMid = true;
             }
 
-            // Set rngMid
-            if (recalcRngCntr) {
+            if (recalcRngMid) {
+                // Set rngMid
+
                 rngMid = dataBuf.getMid(numBufVals);
+
                 if (rngMid == dbMAX_VAL) {
                     rngMid = 0;
                 } else {
@@ -401,31 +253,32 @@ void Chart::calcChrtBorders(double& rngMin, double& rngMid, double& rngMax, doub
                     rngMin = dataBuf.getMin(numBufVals);
                     rngMax = dataBuf.getMax(numBufVals);
                     rng = (rngMax >= rngMin ? rngMax - rngMin : M_TWOPI - rngMin + rngMax);
-                    rng = max(rng, dfltRng); // keep at least default chart range
+                    rng = std::max(rng, dfltRng); // keep at least default chart range
+
                     if (rng > M_PI) { // If wind range > 180°, adjust wndCenter to smaller wind range end
                         rngMid = WindUtils::to2PI(rngMid + M_PI);
                     }
                 }
-                recalcRngCntr = false; // Reset flag for <rngMid> determination
-                LOG_DEBUG(GwLog::DEBUG, "calcChrtRange: rngMid: %.1f°, rngMin: %.1f°, rngMax: %.1f°, rng: %.1f°, rngStep: %.1f°", rngMid * RAD_TO_DEG, rngMin * RAD_TO_DEG, rngMax * RAD_TO_DEG,
+                recalcRngMid = false; // Reset flag for <rngMid> determination
+
+                LOG_DEBUG(GwLog::DEBUG, "calcChrtRange: rngMin: %.1f°, rngMid: %.1f°, rngMax: %.1f°, rng: %.1f°, rngStep: %.1f°", rngMin * RAD_TO_DEG, rngMid * RAD_TO_DEG, rngMax * RAD_TO_DEG,
                     rng * RAD_TO_DEG, rngStep * RAD_TO_DEG);
             }
-
-        } else if (chrtDataFmt == 'R') {
-            // Chart data is of type 'rotation'; then we want to have <rndMid> always to be '0'
-            rngMid = 0;
         }
 
-        // check and adjust range between left, center, and right chart limit
+        // check and adjust range between left, mid, and right chart limit
         double halfRng = rng / 2.0; // we calculate with range between <rngMid> and edges
-        double diffRng = getAngleRng(rngMid, numBufVals);
-        diffRng = (diffRng == dbMAX_VAL ? 0 : std::ceil(diffRng / rngStep) * rngStep);
-        // LOG_DEBUG(GwLog::DEBUG, "calcChrtBorders: diffRng: %.1f°, halfRng: %.1f°", diffRng * RAD_TO_DEG, halfRng * RAD_TO_DEG);
+        double tmpRng = getAngleRng(rngMid, numBufVals);
+        tmpRng = (tmpRng == dbMAX_VAL ? 0 : std::ceil(tmpRng / rngStep) * rngStep);
 
-        if (diffRng > halfRng) {
-            halfRng = diffRng; // round to next <rngStep> value
-        } else if (diffRng + rngStep < halfRng) { // Reduce chart range for higher resolution if possible
-            halfRng = max(dfltRng / 2.0, diffRng);
+        // LOG_DEBUG(GwLog::DEBUG, "calcChrtBorders: tmpRng: %.1f°, halfRng: %.1f°", tmpRng * RAD_TO_DEG, halfRng * RAD_TO_DEG);
+
+        if (tmpRng > halfRng) { // expand chart range to new value
+            halfRng = tmpRng;
+        }
+
+        else if (tmpRng + rngStep < halfRng) { // Contract chart range for higher resolution if possible
+            halfRng = std::max(dfltRng / 2.0, tmpRng);
         }
 
         rngMin = WindUtils::to2PI(rngMid - halfRng);
@@ -433,13 +286,11 @@ void Chart::calcChrtBorders(double& rngMin, double& rngMid, double& rngMax, doub
         rngMax = WindUtils::to2PI(rngMax);
 
         rng = halfRng * 2.0;
-        LOG_DEBUG(GwLog::DEBUG, "calcChrtBorders: rngMin: %.1f°, rngMid: %.1f°, rngMax: %.1f°, diffRng: %.1f°, rng: %.1f°, rngStep: %.1f°", rngMin * RAD_TO_DEG, rngMid * RAD_TO_DEG, rngMax * RAD_TO_DEG,
-            diffRng * RAD_TO_DEG, rng * RAD_TO_DEG, rngStep * RAD_TO_DEG);
+
+        LOG_DEBUG(GwLog::DEBUG, "calcChrtBorders: rngMin: %.1f°, rngMid: %.1f°, rngMax: %.1f°, tmpRng: %.1f°, rng: %.1f°, rngStep: %.1f°", rngMin * RAD_TO_DEG, rngMid * RAD_TO_DEG, rngMax * RAD_TO_DEG,
+            tmpRng * RAD_TO_DEG, rng * RAD_TO_DEG, rngStep * RAD_TO_DEG);
 
     } else { // chart data is of any other type
-
-        double oldRngMin = rngMin;
-        double oldRngMax = rngMax;
 
         double currMinVal = dataBuf.getMin(numBufVals);
         double currMaxVal = dataBuf.getMax(numBufVals);
@@ -449,10 +300,10 @@ void Chart::calcChrtBorders(double& rngMin, double& rngMid, double& rngMax, doub
         }
 
         // check if current chart border have to be adjusted
-        if (currMinVal < oldRngMin || (currMinVal > (oldRngMin + rngStep))) { // decrease rngMin if required or increase if lowest value is higher than old rngMin
+        if (currMinVal < rngMin || (currMinVal > (rngMin + rngStep))) { // decrease rngMin if required or increase if lowest value is higher than old rngMin
             rngMin = std::floor(currMinVal / rngStep) * rngStep; // align low range to lowest buffer value and nearest range interval
         }
-        if ((currMaxVal > oldRngMax) || (currMaxVal < (oldRngMax - rngStep))) { // increase rngMax if required or decrease if lowest value is lower than old rngMax
+        if ((currMaxVal > rngMax) || (currMaxVal < (rngMax - rngStep))) { // increase rngMax if required or decrease if lowest value is lower than old rngMax
             rngMax = std::ceil(currMaxVal / rngStep) * rngStep;
         }
 
@@ -474,8 +325,112 @@ void Chart::calcChrtBorders(double& rngMin, double& rngMid, double& rngMax, doub
     }
 }
 
+// Draw chart graph
+void Chart::drawChartLines(const char direction, const int8_t chrtIntv, const double chrtScale)
+{
+    double chrtVal; // Current data value
+    Pos point, prevPoint; // current and previous chart point
+
+    for (int i = 0; i < (numBufVals / chrtIntv); i++) {
+
+        chrtVal = dataBuf.get(bufStart + (i * chrtIntv)); // show the latest wind values in buffer; keep 1st value constant in a rolling buffer
+
+        if (chrtVal == dbMAX_VAL) {
+            chrtPrevVal = dbMAX_VAL;
+        } else {
+
+            point = setCurrentChartPoint(i, direction, chrtVal, chrtScale);
+
+            // if (i >= (numBufVals / chrtIntv) - 5) // log chart data of 1 line (adjust for test purposes)
+            //    LOG_DEBUG(GwLog::DEBUG, "PageWindPlot Chart: i: %d, chrtVal: %.2f, chrtMin: %.2f, {x,y} {%d,%d}", i, chrtVal, chrtMin, x, y);
+
+            if ((i == 0) || (chrtPrevVal == dbMAX_VAL)) {
+                // just a dot for 1st chart point or after some invalid values
+                prevPoint = point;
+
+            } else if (chrtDataFmt == WIND || chrtDataFmt == ROTATION) {
+                // cross borders check for degree values; shift values to [-PI..0..PI]; when crossing borders, range is 2x PI degrees
+
+                double normCurrVal = WindUtils::to2PI(chrtVal - chrtMin);
+                double normPrevVal = WindUtils::to2PI(chrtPrevVal - chrtMin);
+                // Check if pixel positions are far apart (crossing chart boundary); happens when one value is near chrtMax and the other near chrtMin
+                bool crossedBorders = std::abs(normCurrVal - normPrevVal) > (chrtRng / 2.0);
+
+                if (crossedBorders) { // If current value crosses chart borders compared to previous value, split line
+                    // LOG_DEBUG(GwLog::DEBUG, "PageWindPlot Chart: crossedBorders: %d, chrtVal: %.2f, chrtPrevVal: %.2f", crossedBorders, chrtVal, chrtPrevVal);
+                    bool wrappingFromHighToLow = normCurrVal < normPrevVal; // Determine which edge we're crossing
+
+                    if (direction == HORIZONTAL) {
+                        int ySplit = wrappingFromHighToLow ? (cRoot.y + valAxis) : cRoot.y;
+                        drawBoldLine(prevPoint.x, prevPoint.y, point.x, ySplit);
+                        prevPoint.y = wrappingFromHighToLow ? cRoot.y : (cRoot.y + valAxis);
+
+                    } else { // vertical chart
+                        int xSplit = wrappingFromHighToLow ? (cRoot.x + valAxis) : cRoot.x;
+                        drawBoldLine(prevPoint.x, prevPoint.y, xSplit, point.y);
+                        prevPoint.x = wrappingFromHighToLow ? cRoot.x : (cRoot.x + valAxis);
+                    }
+                }
+            }
+
+            if (chrtDataFmt == DEPTH) {
+                if (direction == HORIZONTAL) { // horizontal chart
+                    drawBoldLine(point.x, point.y, point.x, cRoot.y + valAxis);
+                } else { // vertical chart
+                    drawBoldLine(point.x, point.y, cRoot.x + valAxis, point.y);
+                }
+            } else {
+                drawBoldLine(prevPoint.x, prevPoint.y, point.x, point.y);
+            }
+
+            chrtPrevVal = chrtVal;
+            prevPoint = point;
+        }
+
+        // Reaching chart area top end
+        if (i >= timAxis - 1) {
+            oldChrtIntv = 0; // force reset of buffer start and number of values to show in next display loop
+
+            if (chrtDataFmt == WIND) { // degree of course or wind
+                recalcRngMid = true;
+                LOG_DEBUG(GwLog::DEBUG, "PageWindPlot: chart end: timAxis: %d, i: %d, bufStart: %d, numBufVals: %d, recalcRngCntr: %d", timAxis, i, bufStart, numBufVals, recalcRngMid);
+            }
+            break;
+        }
+    }
+}
+
+// Set current chart point to draw
+Pos Chart::setCurrentChartPoint(const int i, const char direction, const double chrtVal, const double chrtScale)
+{
+    Pos currentPoint;
+
+    if (direction == HORIZONTAL) {
+        currentPoint.x = cRoot.x + i; // Position in chart area
+
+        if (chrtDataFmt == WIND || chrtDataFmt == ROTATION) { // degree type value
+            currentPoint.y = cRoot.y + static_cast<int>((WindUtils::to2PI(chrtVal - chrtMin) * chrtScale) + 0.5); // calculate chart point and round
+        } else if (chrtDataFmt == SPEED or chrtDataFmt == TEMPERATURE) { // speed or temperature data format -> print low values at bottom
+            currentPoint.y = cRoot.y + valAxis - static_cast<int>(((chrtVal - chrtMin) * chrtScale) + 0.5); // calculate chart point and round
+        } else { // any other data format
+            currentPoint.y = cRoot.y + static_cast<int>(((chrtVal - chrtMin) * chrtScale) + 0.5); // calculate chart point and round
+        }
+
+    } else { // vertical chart
+        currentPoint.y = cRoot.y + timAxis - i; // Position in chart area
+
+        if (chrtDataFmt == WIND || chrtDataFmt == ROTATION) { // degree type value
+            currentPoint.x = cRoot.x + static_cast<int>((WindUtils::to2PI(chrtVal - chrtMin) * chrtScale) + 0.5); // calculate chart point and round
+        } else {
+            currentPoint.x = cRoot.x + static_cast<int>(((chrtVal - chrtMin) * chrtScale) + 0.5); // calculate chart point and round
+        }
+    }
+
+    return currentPoint;
+}
+
 // chart time axis label + lines
-void Chart::drawChrtTimeAxis(const char chrtDir, const int8_t chrtSz, int8_t& chrtIntv)
+void Chart::drawChrtTimeAxis(const char chrtDir, const int8_t chrtSz, const int8_t chrtIntv)
 {
     float axSlots, intv, i;
     char sTime[6];
@@ -488,7 +443,7 @@ void Chart::drawChrtTimeAxis(const char chrtDir, const int8_t chrtSz, int8_t& ch
     intv = timAxis / (axSlots - 1); // minutes per chart axis interval (interval is 1 less than axSlots)
     i = timeRng; // Chart axis label start at -32, -16, -12, ... minutes
 
-    if (chrtDir == 'H') { // horizontal chart
+    if (chrtDir == HORIZONTAL) {
         getdisplay().fillRect(0, cRoot.y, dWidth, 2, fgColor);
 
         for (float j = 0; j < timAxis - 1; j += intv) { // fill time axis with values but keep area free on right hand side for value label
@@ -510,11 +465,11 @@ void Chart::drawChrtTimeAxis(const char chrtDir, const int8_t chrtSz, int8_t& ch
             snprintf(sTime, sizeof(sTime), "-%.0f", i);
             getdisplay().drawLine(cRoot.x, cRoot.y + j, cRoot.x + valAxis, cRoot.y + j, fgColor); // Grid line
 
-            if (chrtSz == 0) { // full size chart
+            if (chrtSz == FULL_SIZE) { // full size chart
                 getdisplay().fillRect(0, cRoot.y + j - 9, 32, 15, bgColor); // clear small area to remove potential chart lines
                 getdisplay().setCursor((4 - strlen(sTime)) * 7, cRoot.y + j + 3); // time value; print left screen; value right-formated
                 getdisplay().printf("%s", sTime); // Range value
-            } else if (chrtSz == 2) { // half size chart; right side
+            } else if (chrtSz == HALF_SIZE_RIGHT) { // half size chart; right side
                 drawTextCenter(dWidth / 2, cRoot.y + j, sTime); // time value; print mid screen
             }
         }
@@ -522,92 +477,72 @@ void Chart::drawChrtTimeAxis(const char chrtDir, const int8_t chrtSz, int8_t& ch
 }
 
 // chart value axis labels + lines
-void Chart::drawChrtValAxis(const char chrtDir, const int8_t chrtSz)
+void Chart::drawChrtValAxis(const char chrtDir, const int8_t chrtSz, bool prntName)
 {
-    double axLabel;
-    double cVal;
-    // char sVal[6];
+    const GFXfont* font;
+    constexpr bool NO_LABEL = false;
+    constexpr bool LABEL = true;
 
     getdisplay().setTextColor(fgColor);
 
-    if (chrtDir == 'H') {
+    if (chrtDir == HORIZONTAL) {
 
-        // print buffer data name on right hand side of time axis (max. size 5 characters)
-        getdisplay().setFont(&Ubuntu_Bold12pt8b);
-        drawTextRalign(cRoot.x + timAxis, cRoot.y - 3, dbName.substring(0, 5));
+        if (chrtSz == FULL_SIZE) {
 
-        if (chrtSz == 0) { // full size chart
+            font = &Ubuntu_Bold12pt8b;
 
-            if (chrtDataFmt == 'W') {
-                prntHorizThreeValueAxisLabel(&Ubuntu_Bold12pt8b);
+            // print buffer data name on right hand side of time axis (max. size 5 characters)
+            getdisplay().setFont(font);
+            drawTextRalign(cRoot.x + timAxis, cRoot.y - 3, dbName.substring(0, 5));
+
+            if (chrtDataFmt == WIND) {
+                prntHorizChartThreeValueAxisLabel(font);
                 return;
             }
 
             // for any other data formats print multiple axis value lines on full charts
-            prntHorizMultiValueAxisLabel(&Ubuntu_Bold12pt8b);
+            prntHorizChartMultiValueAxisLabel(font);
             return;
 
         } else { // half size chart -> just print edge values + middle chart line
-            LOG_DEBUG(GwLog::DEBUG, "Chart::drawChrtValAxis: chrtDataFmt: %c, chrtMin: %.2f, chrtMid: %.2f, chrtMax: %.2f", chrtDataFmt, chrtMin, chrtMid, chrtMax);
 
-            prntHorizThreeValueAxisLabel(&Ubuntu_Bold10pt8b);
+            font = &Ubuntu_Bold10pt8b;
+
+            if (prntName) {
+                // print buffer data name on right hand side of time axis (max. size 5 characters)
+                getdisplay().setFont(font);
+                drawTextRalign(cRoot.x + timAxis, cRoot.y - 3, dbName.substring(0, 5));
+            }
+
+            prntHorizChartThreeValueAxisLabel(font);
             return;
         }
 
     } else { // vertical chart
-        char sVal[6];
 
-        if (chrtSz == 0) { // full size chart
-            getdisplay().setFont(&Ubuntu_Bold12pt8b); // use larger font
+        if (chrtSz == FULL_SIZE) {
+            font = &Ubuntu_Bold12pt8b;
+            getdisplay().setFont(font); // use larger font
             drawTextRalign(cRoot.x + (valAxis * 0.42), cRoot.y - 2, dbName.substring(0, 6)); // print buffer data name (max. size 5 characters)
+
         } else {
-            getdisplay().setFont(&Ubuntu_Bold10pt8b); // use smaller font
-        }
-        getdisplay().fillRect(cRoot.x, cRoot.y, valAxis, 2, fgColor); // top chart line
 
-        cVal = chrtMin;
-        cVal = convertValue(cVal, dbName, dbFormat, *commonData); // value (converted)
-        if (useSimuData) { // dirty fix for problem that OBP60Formatter can only be used without data simulation -> returns random values in simulation mode
-            cVal = chrtMin; // no value conversion
+            font = &Ubuntu_Bold10pt8b;
         }
-        snprintf(sVal, sizeof(sVal), "%.0f", round(cVal));
-        getdisplay().setCursor(cRoot.x, cRoot.y - 2);
-        getdisplay().printf("%s", sVal); // Range low end
 
-        cVal = chrtMid;
-        cVal = convertValue(cVal, dbName, dbFormat, *commonData); // value (converted)
-        if (useSimuData) { // dirty fix for problem that OBP60Formatter can only be used without data simulation -> returns random values in simulation mode
-            cVal = chrtMid; // no value conversion
-        }
-        snprintf(sVal, sizeof(sVal), "%.0f", round(cVal));
-        drawTextCenter(cRoot.x + (valAxis / 2), cRoot.y - 9, sVal); // Range mid end
-
-        cVal = chrtMax;
-        cVal = convertValue(cVal, dbName, dbFormat, *commonData); // value (converted)
-        if (useSimuData) { // dirty fix for problem that OBP60Formatter can only be used without data simulation -> returns random values in simulation mode
-            cVal = chrtMax; // no value conversion
-        }
-        snprintf(sVal, sizeof(sVal), "%.0f", round(cVal));
-        drawTextRalign(cRoot.x + valAxis - 2, cRoot.y - 2, sVal); // Range high end
-
-        // draw vertical grid lines for each axis label
-        for (int j = 0; j <= valAxis; j += (valAxis / 2)) {
-            getdisplay().drawLine(cRoot.x + j, cRoot.y, cRoot.x + j, cRoot.y + timAxis, fgColor);
-        }
+        prntVerticChartThreeValueAxisLabel(font);
     }
 }
 
 // Print current data value
-void Chart::prntCurrValue(const char chrtDir, GwApi::BoatValue& currValue)
+void Chart::prntCurrValue(const char direction, GwApi::BoatValue& currValue)
 {
-    const int xPosVal = (chrtDir == 'H') ? cRoot.x + (timAxis / 2) - 56 : cRoot.x + 32;
-    const int yPosVal = (chrtDir == 'H') ? cRoot.y + valAxis - 7 : cRoot.y + timAxis - 7;
+    const int xPosVal = (direction == HORIZONTAL) ? cRoot.x + (timAxis / 2) - 56 : cRoot.x + 32;
+    const int yPosVal = (direction == HORIZONTAL) ? cRoot.y + valAxis - 7 : cRoot.y + timAxis - 7;
 
-    FormattedData frmtDbData = formatValue(&currValue, *commonData);
+    FormattedData frmtDbData = formatValue(&currValue, *commonData, NO_SIMUDATA);
     String sdbValue = frmtDbData.svalue; // value as formatted string
     String dbUnit = frmtDbData.unit; // Unit of value; limit length to 3 characters
-    // LOG_DEBUG(GwLog::DEBUG, "Chart CurrValue: dbValue: %.2f, sdbValue: %s, dbFormat: %s, dbUnit: %s, Valid: %d, Name: %s, Address: %p", currValue.value, sdbValue,
-    //   currValue.getFormat(), dbUnit, currValue.valid, currValue.getName(), currValue);
 
     getdisplay().fillRect(xPosVal - 1, yPosVal - 35, 128, 41, bgColor); // Clear area for TWS value
     getdisplay().drawRect(xPosVal, yPosVal - 34, 126, 40, fgColor); // Draw box for TWS value
@@ -625,28 +560,28 @@ void Chart::prntCurrValue(const char chrtDir, GwApi::BoatValue& currValue)
 }
 
 // print message for no valid data availabletemplate <typename T>
-void Chart::prntNoValidData(const char chrtDir)
+void Chart::prntNoValidData(const char direction)
 {
-    int pX, pY;
+    Pos p;
 
     getdisplay().setFont(&Ubuntu_Bold10pt8b);
 
-    if (chrtDir == 'H') {
-        pX = cRoot.x + (timAxis / 2);
-        pY = cRoot.y + (valAxis / 2) - 10;
+    if (direction == HORIZONTAL) {
+        p.x = cRoot.x + (timAxis / 2);
+        p.y = cRoot.y + (valAxis / 2) - 10;
     } else {
-        pX = cRoot.x + (valAxis / 2);
-        pY = cRoot.y + (timAxis / 2) - 10;
+        p.x = cRoot.x + (valAxis / 2);
+        p.y = cRoot.y + (timAxis / 2) - 10;
     }
 
-    getdisplay().fillRect(pX - 37, pY - 10, 78, 24, bgColor); // Clear area for message
-    drawTextCenter(pX, pY, "No data");
+    getdisplay().fillRect(p.x - 37, p.y - 10, 78, 24, bgColor); // Clear area for message
+    drawTextCenter(p.x, p.y, "No data");
 
     LOG_DEBUG(GwLog::LOG, "Page chart <%s>: No valid data available", dbName);
 }
 
 // Get maximum difference of last <amount> of dataBuf ringbuffer values to center chart; for angle data only
-double Chart::getAngleRng(double center, size_t amount)
+double Chart::getAngleRng(const double center, size_t amount)
 {
     size_t count = dataBuf.getCurrentSize();
 
@@ -680,8 +615,39 @@ double Chart::getAngleRng(double center, size_t amount)
     return (maxRng != dbMIN_VAL ? maxRng : dbMAX_VAL); // Return range from <mid> to <max>
 }
 
-// print horizontal axis label with only three values: top, mid, and bottom
-void Chart::prntHorizThreeValueAxisLabel(const GFXfont* font)
+ // print value axis label with only three values: top, mid, and bottom for vertical chart
+ void Chart::prntVerticChartThreeValueAxisLabel(const GFXfont* font)
+{
+    double cVal;
+    char sVal[7];
+
+    getdisplay().fillRect(cRoot.x, cRoot.y, valAxis, 2, fgColor); // top chart line
+    getdisplay().setFont(font);
+
+    cVal = chrtMin;
+    cVal = convertValue(cVal, dbName, dbFormat, *commonData); // value (converted)
+    snprintf(sVal, sizeof(sVal), "%.0f", round(cVal));
+    getdisplay().setCursor(cRoot.x, cRoot.y - 2);
+    getdisplay().printf("%s", sVal); // Range low end
+
+    cVal = chrtMid;
+    cVal = convertValue(cVal, dbName, dbFormat, *commonData); // value (converted)
+    snprintf(sVal, sizeof(sVal), "%.0f", round(cVal));
+    drawTextCenter(cRoot.x + (valAxis / 2), cRoot.y - 9, sVal); // Range mid end
+
+    cVal = chrtMax;
+    cVal = convertValue(cVal, dbName, dbFormat, *commonData); // value (converted)
+    snprintf(sVal, sizeof(sVal), "%.0f", round(cVal));
+    drawTextRalign(cRoot.x + valAxis - 2, cRoot.y - 2, sVal); // Range high end
+
+    // draw vertical grid lines for each axis label
+    for (int j = 0; j <= valAxis; j += (valAxis / 2)) {
+        getdisplay().drawLine(cRoot.x + j, cRoot.y, cRoot.x + j, cRoot.y + timAxis, fgColor);
+    }
+}
+
+// print value axis label with only three values: top, mid, and bottom for horizontal chart
+void Chart::prntHorizChartThreeValueAxisLabel(const GFXfont* font)
 {
     double axLabel;
     double chrtMin, chrtMid, chrtMax;
@@ -706,28 +672,28 @@ void Chart::prntHorizThreeValueAxisLabel(const GFXfont* font)
     chrtMax = std::round(chrtMax * 100.0) / 100.0;
 
     // print top axis label
-    axLabel = (chrtDataFmt == 'S' || chrtDataFmt == 'T') ? chrtMax : chrtMin;
+    axLabel = (chrtDataFmt == SPEED || chrtDataFmt == TEMPERATURE) ? chrtMax : chrtMin;
     sVal = formatLabel(axLabel);
-    getdisplay().fillRect(cRoot.x, cRoot.y + 2, xOffset + 4, yOffset, bgColor); // Clear small area to remove potential chart lines
+    getdisplay().fillRect(cRoot.x, cRoot.y + 2, xOffset + 3, yOffset, bgColor); // Clear small area to remove potential chart lines
     drawTextRalign(cRoot.x + xOffset, cRoot.y + yOffset, sVal); // range value
 
     // print mid axis label
     axLabel = chrtMid;
     sVal = formatLabel(axLabel);
-    getdisplay().fillRect(cRoot.x, cRoot.y + (valAxis / 2) - 8, xOffset + 4, 16, bgColor); // Clear small area to remove potential chart lines
+    getdisplay().fillRect(cRoot.x, cRoot.y + (valAxis / 2) - 8, xOffset + 3, 16, bgColor); // Clear small area to remove potential chart lines
     drawTextRalign(cRoot.x + xOffset, cRoot.y + (valAxis / 2) + 6, sVal); // range value
-    getdisplay().drawLine(cRoot.x + xOffset + 4, cRoot.y + (valAxis / 2), cRoot.x + timAxis, cRoot.y + (valAxis / 2), fgColor);
+    getdisplay().drawLine(cRoot.x + xOffset + 3, cRoot.y + (valAxis / 2), cRoot.x + timAxis, cRoot.y + (valAxis / 2), fgColor);
 
     // print bottom axis label
-    axLabel = (chrtDataFmt == 'S' || chrtDataFmt == 'T') ? chrtMin : chrtMax;
+    axLabel = (chrtDataFmt == SPEED || chrtDataFmt == TEMPERATURE) ? chrtMin : chrtMax;
     sVal = formatLabel(axLabel);
-    getdisplay().fillRect(cRoot.x, cRoot.y + valAxis - 16, xOffset + 3, 16, bgColor); // Clear small area to remove potential chart lines
+    getdisplay().fillRect(cRoot.x, cRoot.y + valAxis - 14, xOffset + 3, 15, bgColor); // Clear small area to remove potential chart lines
     drawTextRalign(cRoot.x + xOffset, cRoot.y + valAxis, sVal); // range value
-    getdisplay().drawLine(cRoot.x + xOffset + 2, cRoot.y + valAxis, cRoot.x + timAxis, cRoot.y + valAxis, fgColor);
+    getdisplay().drawLine(cRoot.x + xOffset + 3, cRoot.y + valAxis, cRoot.x + timAxis, cRoot.y + valAxis, fgColor);
 }
 
-// print horizontal axis label with multiple axis lines
-void Chart::prntHorizMultiValueAxisLabel(const GFXfont* font)
+// print value axis label with multiple axis lines for horizontal chart
+void Chart::prntHorizChartMultiValueAxisLabel(const GFXfont* font)
 {
     double chrtMin, chrtMax, chrtRng;
     double axSlots, axIntv, axLabel;
@@ -755,7 +721,7 @@ void Chart::prntHorizMultiValueAxisLabel(const GFXfont* font)
     LOG_DEBUG(GwLog::DEBUG, "Chart::printHorizMultiValueAxisLabel: chrtRng: %.2f, th-chrtRng: %.2f, axSlots: %.2f, axIntv: %.2f, axLabel: %.2f, chrtMin: %.2f, chrtMid: %.2f, chrtMax: %.2f", chrtRng, this->chrtRng, axSlots, axIntv, axLabel, this->chrtMin, chrtMid, chrtMax);
 
     int loopStrt, loopEnd, loopStp;
-    if (chrtDataFmt == 'S' || chrtDataFmt == 'T' || chrtDataFmt == 'O') {
+    if (chrtDataFmt == SPEED || chrtDataFmt == TEMPERATURE || chrtDataFmt == OTHER) {
         // High value at top
         loopStrt = valAxis - VALAXIS_STEP;
         loopEnd = VALAXIS_STEP / 2;
@@ -769,8 +735,7 @@ void Chart::prntHorizMultiValueAxisLabel(const GFXfont* font)
 
     for (int j = loopStrt; (loopStp > 0) ? (j < loopEnd) : (j > loopEnd); j += loopStp) {
         sVal = formatLabel(axLabel);
-        // sVal = convNformatLabel(axLabel);
-        getdisplay().fillRect(cRoot.x, cRoot.y + j - 11, xOffset + 4, 21, bgColor); // Clear small area to remove potential chart lines
+        getdisplay().fillRect(cRoot.x, cRoot.y + j - 11, xOffset + 3, 21, bgColor); // Clear small area to remove potential chart lines
         drawTextRalign(cRoot.x + xOffset, cRoot.y + j + 7, sVal); // range value
         getdisplay().drawLine(cRoot.x + xOffset + 3, cRoot.y + j, cRoot.x + timAxis, cRoot.y + j, fgColor);
 
@@ -779,9 +744,8 @@ void Chart::prntHorizMultiValueAxisLabel(const GFXfont* font)
 }
 
 // Draw chart line with thickness of 2px
-void Chart::drawBoldLine(int16_t x1, int16_t y1, int16_t x2, int16_t y2)
+void Chart::drawBoldLine(const int16_t x1, const int16_t y1, const int16_t x2, const int16_t y2)
 {
-
     int16_t dx = std::abs(x2 - x1);
     int16_t dy = std::abs(y2 - y1);
 
@@ -795,7 +759,7 @@ void Chart::drawBoldLine(int16_t x1, int16_t y1, int16_t x2, int16_t y2)
 }
 
 // Convert and format current axis label to user defined format; helper function for easier handling of OBP60Formatter
-String Chart::convNformatLabel(double label)
+String Chart::convNformatLabel(const double& label)
 {
     GwApi::BoatValue tmpBVal(dbName); // temporary boat value for string formatter
     String sVal;
@@ -803,9 +767,9 @@ String Chart::convNformatLabel(double label)
     tmpBVal.setFormat(dbFormat);
     tmpBVal.valid = true;
     tmpBVal.value = label;
-    sVal = formatValue(&tmpBVal, *commonData).svalue; // Formatted value as string including unit conversion and switching decimal places
+    sVal = formatValue(&tmpBVal, *commonData, NO_SIMUDATA).svalue; // Formatted value as string including unit conversion and switching decimal places
     if (sVal.length() > 0 && sVal[0] == '!') {
-        sVal = sVal.substring(1); // cut leading "!" created at OBPFormatter for use with other font than 7SEG
+        sVal = sVal.substring(1); // cut leading "!" created at OBPFormatter; doesn't work for other fonts than 7SEG
     }
 
     return sVal;

--- a/lib/obp60task/OBPcharts.h
+++ b/lib/obp60task/OBPcharts.h
@@ -26,7 +26,7 @@ protected:
     int top = 44; // chart gap at top of display (25 lines for standard gap + 19 lines for axis labels)
     int bottom = 25; // chart gap at bottom of display to keep space for status line
     int hGap = 11; // gap between 2 horizontal charts; actual gap is 2x <gap>
-    int vGap = 20; // gap between 2 vertical charts; actual gap is 2x <gap>
+    int vGap = 17; // gap between 2 vertical charts; actual gap is 2x <gap>
     int dWidth; // Display width
     int dHeight; // Display height
     int timAxis, valAxis; // size of time and value chart axis

--- a/lib/obp60task/OBPcharts.h
+++ b/lib/obp60task/OBPcharts.h
@@ -22,6 +22,8 @@ protected:
     uint16_t fgColor; // color code for any screen writing
     uint16_t bgColor; // color code for screen background
     bool useSimuData; // flag to indicate if simulation data is active
+    String tempFormat; // user defined format for temperature
+    double zeroValue; // "0" SI value for temperature
 
     int top = 44; // chart gap at top of display (25 lines for standard gap + 19 lines for axis labels)
     int bottom = 25; // chart gap at bottom of display to keep space for status line
@@ -50,30 +52,35 @@ protected:
     size_t currIdx; // Current index in TWD history buffer
     size_t lastIdx; // Last index of TWD history buffer
     size_t lastAddedIdx = 0; // Last index of TWD history buffer when new data was added
+    int numNoData; // Counter for multiple invalid data values in a row
     bool bufDataValid = false; // Flag to indicate if buffer data is valid
     int oldChrtIntv = 0; // remember recent user selection of data interval
 
+    double chrtPrevVal; // Last data value in chart area
+    int x, y; // x and y coordinates for drawing
+    int prevX, prevY; // Last x and y coordinates for drawing
+
     void drawChrt(int8_t chrtIntv, GwApi::BoatValue& currValue); // Draw chart line
-    double getRng(double center, size_t amount); // Calculate range between chart center and edges
-    void calcChrtBorders(double& rngMid, double& rngMin, double& rngMax, double& rng); // Calculate chart points for value axis and return range between <min> and <max>
+    void calcChrtBorders(double& rngMin, double& rngMid, double& rngMax, double& rng); // Calculate chart points for value axis and return range between <min> and <max>
     void drawChrtTimeAxis(int8_t chrtIntv); // Draw time axis of chart, value and lines
     void drawChrtValAxis(); // Draw value axis of chart, value and lines
     void prntCurrValue(GwApi::BoatValue& currValue); // Add current boat data value to chart
+    double getAngleRng(double center, size_t amount); // Calculate range between chart center and edges
 
 public:
     // Define default chart range for each boat data type
-    static std::map<String, double> dfltChartRng;
+    static std::map<String, double> dfltChrtRng;
 
     Chart(RingBuffer<T>& dataBuf, char chrtDir, int8_t chrtSz, double dfltRng, CommonData& common, bool useSimuData); // Chart object of data chart
     ~Chart();
-    void showChrt(int8_t chrtIntv, GwApi::BoatValue currValue, bool showCurrValue); // Perform all actions to draw chart
+    void showChrt(GwApi::BoatValue currValue, int8_t chrtIntv, bool showCurrValue); // Perform all actions to draw chart
 };
 
 template <typename T>
-std::map<String, double> Chart<T>::dfltChartRng = {
+std::map<String, double> Chart<T>::dfltChrtRng = {
     { "formatWind", 60.0 * DEG_TO_RAD }, // default course range 60 degrees
     { "formatCourse", 60.0 * DEG_TO_RAD }, // default course range 60 degrees
     { "formatKnots", 5.1 }, // default speed range in m/s
-    { "formatDepth", 15 }, // default depth range in m
-    { "kelvinToC", 30 } // default temp range in °C/K
+    { "formatDepth", 15.0 }, // default depth range in m
+    { "kelvinToC", 30.0 } // default temp range in °C/K
 };

--- a/lib/obp60task/OBPcharts.h
+++ b/lib/obp60task/OBPcharts.h
@@ -17,15 +17,14 @@ template <typename T>
 class RingBuffer;
 class GwLog;
 
-template <typename T>
 class Chart {
 protected:
     CommonData* commonData;
     GwLog* logger;
 
-    RingBuffer<T>& dataBuf; // Buffer to display
-    char chrtDir; // Chart timeline direction: 'H' = horizontal, 'V' = vertical
-    int8_t chrtSz; // Chart size: [0] = full size, [1] = half size left/top, [2] half size right/bottom
+    RingBuffer<uint16_t>& dataBuf; // Buffer to display
+    //char chrtDir; // Chart timeline direction: 'H' = horizontal, 'V' = vertical
+    //int8_t chrtSz; // Chart size: [0] = full size, [1] = half size left/top, [2] half size right/bottom
     double dfltRng; // Default range of chart, e.g. 30 = [0..30]
     uint16_t fgColor; // color code for any screen writing
     uint16_t bgColor; // color code for screen background
@@ -72,13 +71,14 @@ protected:
     static constexpr int8_t THRESHOLD_NO_DATA = 3;
     static constexpr int8_t VALAXIS_STEP = 60;
 
-    void drawChrt(int8_t& chrtIntv, GwApi::BoatValue& currValue); // Draw chart line
+    bool setChartDimensions(const char direction, const int8_t size); //define dimensions and start points for chart
+    void drawChrt(const char chrtDir, int8_t& chrtIntv, GwApi::BoatValue& currValue); // Draw chart line
     void getBufStartNSize(int8_t& chrtIntv); // Identify buffer size and buffer start position for chart
     void calcChrtBorders(double& rngMin, double& rngMid, double& rngMax, double& rng); // Calculate chart points for value axis and return range between <min> and <max>
-    void drawChrtTimeAxis(int8_t& chrtIntv); // Draw time axis of chart, value and lines
-    void drawChrtValAxis(); // Draw value axis of chart, value and lines
-    void prntCurrValue(GwApi::BoatValue& currValue); // Add current boat data value to chart
-    void prntNoValidData(); // print message for no valid data available
+    void drawChrtTimeAxis(const char chrtDir, const int8_t chrtSz, int8_t& chrtIntv); // Draw time axis of chart, value and lines
+    void drawChrtValAxis(const char chrtDir, const int8_t chrtSz); // Draw value axis of chart, value and lines
+    void prntCurrValue(const char chrtDir, GwApi::BoatValue& currValue); // Add current boat data value to chart
+    void prntNoValidData(const char chrtDir); // print message for no valid data available
     double getAngleRng(double center, size_t amount); // Calculate range between chart center and edges
     void prntHorizThreeValueAxisLabel(const GFXfont* font); // print horizontal axis label with only three values: top, mid, and bottom
     void prntHorizMultiValueAxisLabel(const GFXfont* font); // print horizontal axis label with multiple axis lines
@@ -90,17 +90,9 @@ public:
     // Define default chart range and range step for each boat data type
     static std::map<String, ChartProps> dfltChrtDta;
 
-    Chart(RingBuffer<T>& dataBuf, char chrtDir, int8_t chrtSz, double dfltRng, CommonData& common, bool useSimuData); // Chart object of data chart
+    // Chart(RingBuffer<uint16_t>& dataBuf, char chrtDir, int8_t chrtSz, double dfltRng, CommonData& common, bool useSimuData); // Chart object of data chart
+    Chart(RingBuffer<uint16_t>& dataBuf, double dfltRng, CommonData& common, bool useSimuData); // Chart object of data chart
     ~Chart();
-    void showChrt(GwApi::BoatValue currValue, int8_t& chrtIntv, bool showCurrValue); // Perform all actions to draw chart
-};
-
-template <typename T>
-std::map<String, ChartProps> Chart<T>::dfltChrtDta = {
-    { "formatWind", { 60.0 * DEG_TO_RAD, 10.0 * DEG_TO_RAD } }, // default course range 60 degrees
-    { "formatCourse", { 60.0 * DEG_TO_RAD, 10.0 * DEG_TO_RAD } }, // default course range 60 degrees
-    //{ "formatKnots", { 7.71, 2.57 } }, // default speed range in m/s
-    { "formatKnots", { 7.71, 2.56 } }, // default speed range in m/s
-    { "formatDepth", { 15.0, 5.0 } }, // default depth range in m
-    { "kelvinToC", { 30.0, 5.0 } } // default temp range in °C/K
+    // void showChrt(GwApi::BoatValue currValue, int8_t& chrtIntv, bool showCurrValue); // Perform all actions to draw chart
+    void showChrt(char chrtDir, int8_t chrtSz, int8_t& chrtIntv, bool showCurrValue, GwApi::BoatValue currValue); // Perform all actions to draw chart
 };

--- a/lib/obp60task/OBPcharts.h
+++ b/lib/obp60task/OBPcharts.h
@@ -6,16 +6,16 @@ struct Pos {
     int x;
     int y;
 };
+
 template <typename T> class RingBuffer;
 class GwLog;
 
-template <typename T>
-class Chart {
+template <typename T> class Chart {
 protected:
-    CommonData *commonData;
-    GwLog *logger;
+    CommonData* commonData;
+    GwLog* logger;
 
-    RingBuffer<T> &dataBuf; // Buffer to display
+    RingBuffer<T>& dataBuf; // Buffer to display
     char chrtDir; // Chart timeline direction: 'H' = horizontal, 'V' = vertical
     int8_t chrtSz; // Chart size: [0] = full size, [1] = half size left/top, [2] half size right/bottom
     double dfltRng; // Default range of chart, e.g. 30 = [0..30]
@@ -23,7 +23,6 @@ protected:
     uint16_t bgColor; // color code for screen background
     bool useSimuData; // flag to indicate if simulation data is active
 
-    // int top = 48; // display top header lines
     int top = 44; // chart gap at top of display (25 lines for standard gap + 19 lines for axis labels)
     int bottom = 25; // chart gap at bottom of display to keep space for status line
     int hGap = 11; // gap between 2 horizontal charts; actual gap is 2x <gap>
@@ -59,11 +58,22 @@ protected:
     void calcChrtBorders(double& rngMid, double& rngMin, double& rngMax, double& rng); // Calculate chart points for value axis and return range between <min> and <max>
     void drawChrtTimeAxis(int8_t chrtIntv); // Draw time axis of chart, value and lines
     void drawChrtValAxis(); // Draw value axis of chart, value and lines
-    void prntCurrValue(GwApi::BoatValue& currValue); // Add current boat data value to chart 
+    void prntCurrValue(GwApi::BoatValue& currValue); // Add current boat data value to chart
 
 public:
+    // Define default chart range for each boat data type
+    static std::map<String, double> dfltChartRng;
+
     Chart(RingBuffer<T>& dataBuf, char chrtDir, int8_t chrtSz, double dfltRng, CommonData& common, bool useSimuData); // Chart object of data chart
     ~Chart();
-    void showChrt(int8_t chrtIntv, GwApi::BoatValue currValue); // Perform all actions to draw chart
+    void showChrt(int8_t chrtIntv, GwApi::BoatValue currValue, bool showCurrValue); // Perform all actions to draw chart
+};
 
+template <typename T>
+std::map<String, double> Chart<T>::dfltChartRng = {
+    { "formatWind", 60.0 * DEG_TO_RAD }, // default course range 60 degrees
+    { "formatCourse", 60.0 * DEG_TO_RAD }, // default course range 60 degrees
+    { "formatKnots", 5.1 }, // default speed range in m/s
+    { "formatDepth", 15 }, // default depth range in m
+    { "kelvinToC", 30 } // default temp range in °C/K
 };

--- a/lib/obp60task/OBPcharts.h
+++ b/lib/obp60task/OBPcharts.h
@@ -16,19 +16,18 @@ protected:
     GwLog *logger;
 
     RingBuffer<T> &dataBuf; // Buffer to display
-    int8_t chrtDir; // Chart timeline direction: [0] = horizontal, [1] = vertical
+    char chrtDir; // Chart timeline direction: 'H' = horizontal, 'V' = vertical
     int8_t chrtSz; // Chart size: [0] = full size, [1] = half size left/top, [2] half size right/bottom
     double dfltRng; // Default range of chart, e.g. 30 = [0..30]
     uint16_t fgColor; // color code for any screen writing
     uint16_t bgColor; // color code for screen background
     bool useSimuData; // flag to indicate if simulation data is active
 
-    int top = 48; // display top header lines
-    int bottom = 22; // display bottom lines
+    // int top = 48; // display top header lines
+    int top = 44; // chart gap at top of display (25 lines for standard gap + 19 lines for axis labels)
+    int bottom = 25; // chart gap at bottom of display to keep space for status line
     int hGap = 11; // gap between 2 horizontal charts; actual gap is 2x <gap>
     int vGap = 20; // gap between 2 vertical charts; actual gap is 2x <gap>
-    int xOffset = 33; // offset for horizontal axis (time/value), because of space for left vertical axis labeling
-    int yOffset = 10; // offset for vertical axis (time/value), because of space for top horizontal axis labeling
     int dWidth; // Display width
     int dHeight; // Display height
     int timAxis, valAxis; // size of time and value chart axis
@@ -41,7 +40,7 @@ protected:
     bool recalcRngCntr = false; // Flag for re-calculation of mid value of chart for wind data types
 
     String dbName, dbFormat; // Name and format of data buffer
-    int chrtDataFmt; // Data format of chart: [0] size values; [1] degree of course or wind; [2] rotational degrees
+    char chrtDataFmt; // Data format of chart: 'S' = size values; 'D' = depth value, 'W' = degree of course or wind; 'R' rotational degrees
     double dbMIN_VAL; // Lowest possible value of buffer of type <T>
     double dbMAX_VAL; // Highest possible value of buffer of type <T>; indicates invalid value in buffer
     size_t bufSize; // History buffer size: 1.920 values for 32 min. history chart
@@ -63,7 +62,7 @@ protected:
     void prntCurrValue(GwApi::BoatValue& currValue); // Add current boat data value to chart 
 
 public:
-    Chart(RingBuffer<T>& dataBuf, int8_t chrtDir, int8_t chrtSz, double dfltRng, CommonData& common, bool useSimuData); // Chart object of data chart
+    Chart(RingBuffer<T>& dataBuf, char chrtDir, int8_t chrtSz, double dfltRng, CommonData& common, bool useSimuData); // Chart object of data chart
     ~Chart();
     void showChrt(int8_t chrtIntv, GwApi::BoatValue currValue); // Perform all actions to draw chart
 

--- a/lib/obp60task/PageOneValue.cpp
+++ b/lib/obp60task/PageOneValue.cpp
@@ -3,112 +3,254 @@
 #include "Pagedata.h"
 #include "OBP60Extensions.h"
 #include "BoatDataCalibration.h"
+#include "OBPcharts.h"
 
-class PageOneValue : public Page
-{
-    public:
-    PageOneValue(CommonData &common){
-        commonData = &common;
-        common.logger->logDebug(GwLog::LOG,"Instantiate PageOneValue");
+class PageOneValue : public Page {
+private:
+    GwLog* logger;
+
+    int width; // Screen width
+    int height; // Screen height
+
+    bool keylock = false; // Keylock
+    char pageMode = 'V'; // Page mode: 'V' for value, 'C' for chart, 'B' for both
+    int dataIntv = 1; // Update interval for wind history chart:
+                      // (1)|(2)|(3)|(4)|(8) x 240 seconds for 4, 8, 12, 16, 32 min. history chart
+
+    String lengthformat;
+    bool useSimuData;
+    bool holdValues;
+    String flashLED;
+    String backlightMode;
+
+    // Old values for hold function
+    String sValue1Old = "";
+    String unit1Old = "";
+
+    // Data buffer pointer (owned by HstryBuffers)
+    RingBuffer<uint16_t>* dataHstryBuf = nullptr;
+    std::unique_ptr<Chart<uint16_t>> dataFlChart, dataHfChart; // Chart object, full and half size
+    // Active chart and value
+    Chart<uint16_t>* dataChart = nullptr;
+
+    void showData(GwApi::BoatValue* bValue1, char size)
+    {
+        int nameXoff, nameYoff, unitXoff, unitYoff, value1Xoff, value1Yoff;
+        const GFXfont *nameFnt, *unitFnt, *valueFnt1, *valueFnt2, *valueFnt3;
+
+        if (size == 'F') { // full size data display
+            nameXoff = 0;
+            nameYoff = 0;
+            nameFnt = &Ubuntu_Bold32pt8b;
+            unitXoff = 0;
+            unitYoff = 0;
+            unitFnt = &Ubuntu_Bold20pt8b;
+            value1Xoff = 0;
+            value1Yoff = 0;
+            valueFnt1 = &Ubuntu_Bold20pt8b;
+            valueFnt2 = &Ubuntu_Bold32pt8b;
+            valueFnt3 = &DSEG7Classic_BoldItalic60pt7b;
+        } else { // half size data and chart display
+            nameXoff = 105;
+            nameYoff = -40;
+            nameFnt = &Ubuntu_Bold20pt8b;
+            unitXoff = -33;
+            unitYoff = -40;
+            unitFnt = &Ubuntu_Bold12pt8b;
+            valueFnt1 = &Ubuntu_Bold12pt8b;
+            value1Xoff = 105;
+            value1Yoff = -105;
+            valueFnt2 = &Ubuntu_Bold20pt8b;
+            valueFnt3 = &DSEG7Classic_BoldItalic30pt7b;
+        }
+
+        String name1 = xdrDelete(bValue1->getName()); // Value name
+        name1 = name1.substring(0, 6); // String length limit for value name
+        calibrationData.calibrateInstance(bValue1, logger); // Check if boat data value is to be calibrated
+        double value1 = bValue1->value; // Value as double in SI unit
+        bool valid1 = bValue1->valid; // Valid information
+        String sValue1 = formatValue(bValue1, *commonData).svalue; // Formatted value as string including unit conversion and switching decimal places
+        String unit1 = formatValue(bValue1, *commonData).unit; // Unit of value 
+
+        // Show name
+        getdisplay().setTextColor(commonData->fgcolor);
+        getdisplay().setFont(nameFnt);
+        getdisplay().setCursor(20 + nameXoff, 100 + nameYoff);
+        getdisplay().print(name1); // name
+
+        // Show unit
+        getdisplay().setFont(unitFnt);
+        getdisplay().setCursor(270 + unitXoff, 100 + unitYoff);
+        if (holdValues == false) {
+            //getdisplay().print(unit1); // Unit
+            drawTextRalign(298 + unitXoff, 100 + unitYoff, unit1); // Unit
+
+        } else {
+            // getdisplay().print(unit1Old);
+            drawTextRalign(298 + unitXoff, 100 + unitYoff, unit1Old);
+        }
+
+        // Switch font if format for any values
+        if (bValue1->getFormat() == "formatLatitude" || bValue1->getFormat() == "formatLongitude") {
+            getdisplay().setFont(valueFnt1);
+            getdisplay().setCursor(20 + value1Xoff, 180 + value1Yoff);
+        } else if (bValue1->getFormat() == "formatTime" || bValue1->getFormat() == "formatDate") {
+            getdisplay().setFont(valueFnt2);
+            getdisplay().setCursor(20 + value1Xoff, 200 + value1Yoff);
+        } else {
+            getdisplay().setFont(valueFnt3);
+            getdisplay().setCursor(20 + value1Xoff, 240 + value1Yoff);
+        }
+
+        // Show bus data
+        if (holdValues == false) {
+            getdisplay().print(sValue1); // Real value as formated string
+        } else {
+            getdisplay().print(sValue1Old); // Old value as formated string
+        }
+        if (valid1 == true) {
+            sValue1Old = sValue1; // Save the old value
+            unit1Old = unit1; // Save the old unit
+        }
     }
 
-    virtual int handleKey(int key){
-        // Code for keylock
-        if(key == 11){
+public:
+    PageOneValue(CommonData& common)
+    {
+        commonData = &common;
+        logger = commonData->logger;
+        LOG_DEBUG(GwLog::LOG, "Instantiate PageOneValue");
+
+        width = getdisplay().width(); // Screen width
+        height = getdisplay().height(); // Screen height
+
+        // Get config data
+        lengthformat = common.config->getString(common.config->lengthFormat);
+        useSimuData = common.config->getBool(common.config->useSimuData);
+        holdValues = common.config->getBool(common.config->holdvalues);
+        flashLED = common.config->getString(common.config->flashLED);
+        backlightMode = common.config->getString(common.config->backlight);
+    }
+
+    virtual void setupKeys()
+    {
+        Page::setupKeys();
+        commonData->keydata[0].label = "MODE";
+#if defined BOARD_OBP60S3
+        commonData->keydata[4].label = "ZOOM";
+#elif defined BOARD_OBP40S3
+        commonData->keydata[1].label = "ZOOM";
+#endif
+    }
+
+    // Key functions
+    virtual int handleKey(int key)
+    {
+        // Set page mode value | full chart | value/half chart
+        if (key == 1) {
+            if (pageMode == 'V') {
+                pageMode = 'C';
+            } else if (pageMode == 'C') {
+                pageMode = 'B';
+            } else {
+                pageMode = 'V';
+            }
+            return 0; // Commit the key
+        }
+
+        // Set interval for history chart update time (interval)
+#if defined BOARD_OBP60S3
+        if (key == 5) {
+#elif defined BOARD_OBP40S3
+        if (key == 2) {
+#endif
+            if (dataIntv == 1) {
+                dataIntv = 2;
+            } else if (dataIntv == 2) {
+                dataIntv = 3;
+            } else if (dataIntv == 3) {
+                dataIntv = 4;
+            } else if (dataIntv == 4) {
+                dataIntv = 8;
+            } else {
+                dataIntv = 1;
+            }
+            return 0; // Commit the key
+        }
+
+        // Keylock function
+        if (key == 11) { // Code for keylock
             commonData->keylock = !commonData->keylock;
-            return 0;                   // Commit the key
+            return 0; // Commit the key
         }
         return key;
     }
 
-    int displayPage(PageData &pageData){
-        GwConfigHandler *config = commonData->config;
-        GwLog *logger = commonData->logger;
+    virtual void displayNew(PageData& pageData)
+    {
+#ifdef BOARD_OBP60S3
+        // Clear optical warning
+        if (flashLED == "Limit Violation") {
+            setBlinkingLED(false);
+            setFlashLED(false);
+        }
+#endif
+        if (!dataFlChart) { // Create chart objects if they don't exist
+            GwApi::BoatValue* bValue1 = pageData.values[0]; // Page boat data element
+            String bValName1 = bValue1->getName(); // Value name
+            String bValFormat = bValue1->getFormat(); // Value format
 
-        // Old values for hold function
-        static String svalue1old = "";
-        static String unit1old = "";
+            dataHstryBuf = pageData.hstryBuffers->getBuffer(bValName1);
 
-        // Get config data
-        String lengthformat = config->getString(config->lengthFormat);
-        // bool simulation = config->getBool(config->useSimuData);
-        bool holdvalues = config->getBool(config->holdvalues);
-        String flashLED = config->getString(config->flashLED);
-        String backlightMode = config->getString(config->backlight);
-        
-        // Get boat values
-        GwApi::BoatValue *bvalue1 = pageData.values[0]; // First element in list (only one value by PageOneValue)
-        String name1 = xdrDelete(bvalue1->getName());   // Value name
-        name1 = name1.substring(0, 6);                  // String length limit for value name
-        calibrationData.calibrateInstance(bvalue1, logger); // Check if boat data value is to be calibrated
-        double value1 = bvalue1->value;                 // Value as double in SI unit
-        bool valid1 = bvalue1->valid;                   // Valid information
-        String svalue1 = formatValue(bvalue1, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
-        String unit1 = formatValue(bvalue1, *commonData).unit;        // Unit of value
+            dataFlChart.reset(new Chart<uint16_t>(*dataHstryBuf, 'H', 0, Chart<uint16_t>::dfltChartRng[bValFormat], *commonData, useSimuData));
+            dataHfChart.reset(new Chart<uint16_t>(*dataHstryBuf, 'H', 2, Chart<uint16_t>::dfltChartRng[bValFormat], *commonData, useSimuData));
+            LOG_DEBUG(GwLog::DEBUG, "PageOneValue: Created chart objects for %s", bValName1);
+        }
+    }
+
+    int displayPage(PageData& pageData)
+    {
+
+        LOG_DEBUG(GwLog::LOG, "Display PageOneValue");
+        GwConfigHandler* config = commonData->config;
+        GwLog* logger = commonData->logger;
+
+        // Get boat value for page
+        GwApi::BoatValue* bValue1 = pageData.values[0]; // Page boat data element
 
         // Optical warning by limit violation (unused)
-        if(String(flashLED) == "Limit Violation"){
+        if (String(flashLED) == "Limit Violation") {
             setBlinkingLED(false);
-            setFlashLED(false); 
+            setFlashLED(false);
         }
 
         // Logging boat values
-        if (bvalue1 == NULL) return PAGE_OK; // WTF why this statement?
-        LOG_DEBUG(GwLog::LOG,"Drawing at PageOneValue, %s: %f", name1.c_str(), value1);
+        if (bValue1 == NULL)
+            return PAGE_OK; // WTF why this statement?
+        LOG_DEBUG(GwLog::LOG, "Drawing at PageOneValue, %s: %f", bValue1->getName().c_str(), bValue1->value);
 
         // Draw page
         //***********************************************************
 
-        /// Set display in partial refresh mode
-        getdisplay().setPartialWindow(0, 0, getdisplay().width(), getdisplay().height()); // Set partial update
+        getdisplay().setPartialWindow(0, 0, width, height); // Set partial update
 
-        // Show name
-        getdisplay().setTextColor(commonData->fgcolor);
-        getdisplay().setFont(&Ubuntu_Bold32pt8b);
-        getdisplay().setCursor(20, 100);
-        getdisplay().print(name1);                           // Page name
+        if (pageMode == 'V') { // show only data value
+            showData(bValue1, 'F');
 
-        // Show unit
-        getdisplay().setFont(&Ubuntu_Bold20pt8b);
-        getdisplay().setCursor(270, 100);
-        if(holdvalues == false){
-            getdisplay().print(unit1);                       // Unit
-        }
-        else{
-            getdisplay().print(unit1old);
-        }
+        } else if (pageMode == 'C') { // show only data chart
+            dataFlChart->showChrt(dataIntv, *bValue1, true);
 
-        // Switch font if format for any values
-        if(bvalue1->getFormat() == "formatLatitude" || bvalue1->getFormat() == "formatLongitude"){
-            getdisplay().setFont(&Ubuntu_Bold20pt8b);
-            getdisplay().setCursor(20, 180);
-        }
-        else if(bvalue1->getFormat() == "formatTime" || bvalue1->getFormat() == "formatDate"){
-            getdisplay().setFont(&Ubuntu_Bold32pt8b);
-            getdisplay().setCursor(20, 200);
-        }
-        else{
-            getdisplay().setFont(&DSEG7Classic_BoldItalic60pt7b);
-            getdisplay().setCursor(20, 240);
-        }
-
-        // Show bus data
-        if(holdvalues == false){
-            getdisplay().print(svalue1);                                     // Real value as formated string
-        }
-        else{
-            getdisplay().print(svalue1old);                                  // Old value as formated string
-        }
-        if(valid1 == true){
-            svalue1old = svalue1;                                       // Save the old value
-            unit1old = unit1;                                           // Save the old unit
+        } else if (pageMode == 'B') { // show data value and chart
+            showData(bValue1, 'H');
+            dataHfChart->showChrt(dataIntv, *bValue1, false);
         }
 
         return PAGE_UPDATE;
     };
 };
 
-static Page* createPage(CommonData &common){
+static Page* createPage(CommonData& common)
+{
     return new PageOneValue(common);
 }
 
@@ -120,10 +262,10 @@ static Page* createPage(CommonData &common){
  * this will be number of BoatValue pointers in pageData.values
  */
 PageDescription registerPageOneValue(
-    "OneValue",     // Page name
-    createPage,     // Action
-    1,              // Number of bus values depends on selection in Web configuration
-    true            // Show display header on/off
+    "OneValue", // Page name
+    createPage, // Action
+    1, // Number of bus values depends on selection in Web configuration
+    true // Show display header on/off
 );
 
 #endif

--- a/lib/obp60task/PageOneValue.cpp
+++ b/lib/obp60task/PageOneValue.cpp
@@ -15,8 +15,8 @@ private:
 
     bool keylock = false; // Keylock
     char pageMode = 'V'; // Page mode: 'V' for value, 'C' for chart, 'B' for both
-    int dataIntv = 1; // Update interval for wind history chart:
-                      // (1)|(2)|(3)|(4)|(8) x 240 seconds for 4, 8, 12, 16, 32 min. history chart
+    int8_t dataIntv = 1; // Update interval for wind history chart:
+                         // (1)|(2)|(3)|(4)|(8) x 240 seconds for 4, 8, 12, 16, 32 min. history chart
 
     //String lengthformat;
     bool useSimuData;
@@ -209,8 +209,8 @@ public:
             dataHstryBuf = pageData.hstryBuffers->getBuffer(bValName1);
 
             if (dataHstryBuf) {
-                dataFlChart.reset(new Chart<uint16_t>(*dataHstryBuf, 'H', 0, Chart<uint16_t>::dfltChrtRng[bValFormat], *commonData, useSimuData));
-                dataHfChart.reset(new Chart<uint16_t>(*dataHstryBuf, 'H', 2, Chart<uint16_t>::dfltChrtRng[bValFormat], *commonData, useSimuData));
+                dataFlChart.reset(new Chart<uint16_t>(*dataHstryBuf, 'H', 0, Chart<uint16_t>::dfltChrtDta[bValFormat].range, *commonData, useSimuData));
+                dataHfChart.reset(new Chart<uint16_t>(*dataHstryBuf, 'H', 2, Chart<uint16_t>::dfltChrtDta[bValFormat].range, *commonData, useSimuData));
                 LOG_DEBUG(GwLog::DEBUG, "PageOneValue: Created chart objects for %s", bValName1);
             } else {
                 LOG_DEBUG(GwLog::DEBUG, "PageOneValue: No chart objects available for %s", bValName1);
@@ -224,8 +224,6 @@ public:
     {
 
         LOG_DEBUG(GwLog::LOG, "Display PageOneValue");
-        //GwConfigHandler* config = commonData->config;
-        //GwLog* logger = commonData->logger;
 
         // Get boat value for page
         GwApi::BoatValue* bValue1 = pageData.values[0]; // Page boat data element
@@ -236,24 +234,8 @@ public:
             setFlashLED(false);
         }
 
-/*        if (!dataFlChart) { // Create chart objects if they don't exist
-            GwApi::BoatValue* bValue1 = pageData.values[0]; // Page boat data element
-            String bValName1 = bValue1->getName(); // Value name
-            String bValFormat = bValue1->getFormat(); // Value format
-
-            dataHstryBuf = pageData.hstryBuffers->getBuffer(bValName1);
-
-            if (dataHstryBuf) {
-                dataFlChart.reset(new Chart<uint16_t>(*dataHstryBuf, 'H', 0, Chart<uint16_t>::dfltChrtRng[bValFormat], *commonData, useSimuData));
-                dataHfChart.reset(new Chart<uint16_t>(*dataHstryBuf, 'H', 2, Chart<uint16_t>::dfltChrtRng[bValFormat], *commonData, useSimuData));
-                LOG_DEBUG(GwLog::DEBUG, "PageOneValue: Created chart objects for %s", bValName1);
-            } else {
-                LOG_DEBUG(GwLog::DEBUG, "PageOneValue: No chart objects available for %s", bValName1);
-            }
-        } */
-
         if (bValue1 == NULL)
-            return PAGE_OK; // no data, no display of page
+            return PAGE_OK; // no data, no page to display
 
         LOG_DEBUG(GwLog::DEBUG, "PageOneValue: printing %s, %.3f", bValue1->getName().c_str(), bValue1->value);
 

--- a/lib/obp60task/PageOneValue.cpp
+++ b/lib/obp60task/PageOneValue.cpp
@@ -76,7 +76,7 @@ private:
             nameXoff = -10;
             nameYoff = -34;
             nameFnt = &Ubuntu_Bold20pt8b;
-            unitXoff = 63;
+            unitXoff = -295;
             unitYoff = -119;
             unitFnt = &Ubuntu_Bold12pt8b;
             valueFnt1 = &Ubuntu_Bold12pt8b;

--- a/lib/obp60task/PageOneValue.cpp
+++ b/lib/obp60task/PageOneValue.cpp
@@ -12,8 +12,8 @@ private:
 
     enum PageMode {
         VALUE,
-        CHART,
-        BOTH
+        BOTH,
+        CHART
     };
     enum DisplayMode {
         FULL,
@@ -54,6 +54,7 @@ private:
     RingBuffer<uint16_t>* dataHstryBuf = nullptr;
     std::unique_ptr<Chart> dataChart; // Chart object
 
+    // display data value in display <mode> [FULL|HALF]
     void showData(GwApi::BoatValue* bValue1, DisplayMode mode)
     {
         int nameXoff, nameYoff, unitXoff, unitYoff, value1Xoff, value1Yoff;
@@ -158,17 +159,17 @@ public:
         Page::setupKeys();
 
 #if defined BOARD_OBP60S3
-        constexpr int ZOOM_IDX = 4;
+        constexpr int ZOOM_KEY = 4;
 #elif defined BOARD_OBP40S3
-        constexpr int ZOOM_IDX = 1;
+        constexpr int ZOOM_KEY = 1;
 #endif
 
         if (dataHstryBuf) { // show "Mode" key only if chart supported boat data type is available
             commonData->keydata[0].label = "MODE";
-            commonData->keydata[ZOOM_IDX].label = "ZOOM";
+            commonData->keydata[ZOOM_KEY].label = "ZOOM";
         } else {
             commonData->keydata[0].label = "";
-            commonData->keydata[ZOOM_IDX].label = "";
+            commonData->keydata[ZOOM_KEY].label = "";
         }
     }
 
@@ -177,7 +178,7 @@ public:
     {
         if (dataHstryBuf) { // if boat data type supports charts
 
-            // Set page mode value | value/half chart | full chart
+            // Set page mode: value | value/half chart | full chart
             if (key == 1) {
                 switch (pageMode) {
                 case VALUE:

--- a/lib/obp60task/PageTwoValues.cpp
+++ b/lib/obp60task/PageTwoValues.cpp
@@ -3,176 +3,327 @@
 #include "Pagedata.h"
 #include "OBP60Extensions.h"
 #include "BoatDataCalibration.h"
+#include "OBPDataOperations.h"
+#include "OBPcharts.h"
 
-class PageTwoValues : public Page
-{
-    public:
-    PageTwoValues(CommonData &common){
-        commonData = &common;
-        common.logger->logDebug(GwLog::LOG,"Instantiate PageTwoValue");
+class PageTwoValues : public Page {
+private:
+    GwLog* logger;
+
+    enum PageMode {
+        VALUES,
+        VAL1_CHART,
+        VAL2_CHART,
+        CHARTS
+    };
+    enum DisplayMode {
+        FULL,
+        HALF
+    };
+
+    static constexpr char HORIZONTAL = 'H';
+    static constexpr char VERTICAL = 'V';
+    static constexpr int8_t FULL_SIZE = 0;
+    static constexpr int8_t HALF_SIZE_TOP = 1;
+    static constexpr int8_t HALF_SIZE_BOTTOM = 2;
+
+    static constexpr bool PRNT_NAME = true;
+    static constexpr bool NO_PRNT_NAME = false;
+    static constexpr bool PRNT_VALUE = true;
+    static constexpr bool NO_PRNT_VALUE = false;
+
+    static constexpr int YOFFSET = 130; // y offset for display of 2nd boat value
+
+    int width; // Screen width
+    int height; // Screen height
+
+    bool keylock = false; // Keylock
+    PageMode pageMode = VALUES; // Page display mode
+    int8_t dataIntv = 1; // Update interval for wind history chart:
+                         // (1)|(2)|(3)|(4)|(8) x 240 seconds for 4, 8, 12, 16, 32 min. history chart
+
+    // String lengthformat;
+    bool useSimuData;
+    bool holdValues;
+    String flashLED;
+    String backlightMode;
+    String tempFormat;
+
+    // Data buffer pointer (owned by HstryBuffers)
+    static constexpr int NUMVALUES = 2; // two data values in this page
+    RingBuffer<uint16_t>* dataHstryBuf[NUMVALUES] = { nullptr };
+    std::unique_ptr<Chart> dataChart[NUMVALUES]; // Chart object
+
+    // Old values for hold function
+    String sValueOld[NUMVALUES] = { "", "" };
+    String unitOld[NUMVALUES] = { "", "" };
+
+    // display data values in display <mode> [FULL|HALF]
+    void showData(const std::vector<GwApi::BoatValue*>& bValue, DisplayMode mode)
+    {
+        getdisplay().setTextColor(commonData->fgcolor);
+
+        int numValues = bValue.size(); // do we have to handle 1 or 2 values?
+
+        for (int i = 0; i < numValues; i++) {
+            int yOffset = YOFFSET * i;
+            String name = xdrDelete(bValue[i]->getName()); // Value name
+            name = name.substring(0, 6); // String length limit for value name
+            calibrationData.calibrateInstance(bValue[i], logger); // Check if boat data value is to be calibrated
+            double value = bValue[i]->value; // Value as double in SI unit
+            bool valid = bValue[i]->valid; // Valid information
+            String sValue = formatValue(bValue[i], *commonData).svalue; // Formatted value as string including unit conversion and switching decimal places
+            String unit = formatValue(bValue[i], *commonData).unit; // Unit of value
+
+            // Show name
+            getdisplay().setFont(&Ubuntu_Bold20pt8b);
+            getdisplay().setCursor(20, 75 + yOffset);
+            getdisplay().print(name); // name
+
+            // Show unit
+            getdisplay().setFont(&Ubuntu_Bold12pt8b);
+            getdisplay().setCursor(20, 125 + yOffset);
+
+            if (holdValues) {
+                getdisplay().print(unitOld[i]); // name
+            } else {
+                getdisplay().print(unit); // name
+            }
+
+            // Switch font depending on value format and adjust position
+            if (bValue[i]->getFormat() == "formatLatitude" || bValue[i]->getFormat() == "formatLongitude") {
+                getdisplay().setFont(&Ubuntu_Bold20pt8b);
+                getdisplay().setCursor(50, 125 + yOffset);
+            } else if (bValue[i]->getFormat() == "formatTime" || bValue[i]->getFormat() == "formatDate") {
+                getdisplay().setFont(&Ubuntu_Bold20pt8b);
+                getdisplay().setCursor(170, 105 + yOffset);
+            } else { // Default font for other formats
+                getdisplay().setFont(&DSEG7Classic_BoldItalic42pt7b);
+                getdisplay().setCursor(180, 125 + yOffset);
+            }
+
+            // Show bus data
+            if (!holdValues || useSimuData) {
+                getdisplay().print(sValue); // Real value as formated string
+            } else {
+                getdisplay().print(sValueOld[i]); // Old value as formated string
+            }
+
+            if (valid == true) {
+                sValueOld[i] = sValue; // Save the old value
+                unitOld[i] = unit; // Save the old unit
+            }
+        }
+
+        if (numValues == 2 && mode == FULL) { // print line only, if we want to show 2 data values
+            getdisplay().fillRect(0, 145, width, 3, commonData->fgcolor);             // Horizontal line 3 pix
+        }
     }
 
-    virtual int handleKey(int key){
-        // Code for keylock
-        if(key == 11){
+public:
+    PageTwoValues(CommonData& common)
+    {
+        commonData = &common;
+        logger = commonData->logger;
+        LOG_DEBUG(GwLog::LOG, "Instantiate PageTwoValues");
+
+        width = getdisplay().width(); // Screen width
+        height = getdisplay().height(); // Screen height
+
+        // Get config data
+        // lengthformat = commonData->config->getString(commonData->config->lengthFormat);
+        useSimuData = commonData->config->getBool(commonData->config->useSimuData);
+        holdValues = commonData->config->getBool(commonData->config->holdvalues);
+        flashLED = commonData->config->getString(commonData->config->flashLED);
+        backlightMode = commonData->config->getString(commonData->config->backlight);
+        tempFormat = commonData->config->getString(commonData->config->tempFormat); // [K|°C|°F]
+    }
+
+    virtual void setupKeys()
+    {
+        Page::setupKeys();
+
+#if defined BOARD_OBP60S3
+        constexpr int ZOOM_KEY = 4;
+#elif defined BOARD_OBP40S3
+        constexpr int ZOOM_KEY = 1;
+#endif
+
+        if (dataHstryBuf[0] || dataHstryBuf[1]) { // show "Mode" key only if at least 1 chart supported boat data type is available
+            commonData->keydata[0].label = "MODE";
+            commonData->keydata[ZOOM_KEY].label = "ZOOM";
+        } else {
+            commonData->keydata[0].label = "";
+            commonData->keydata[ZOOM_KEY].label = "";
+        }
+    }
+
+    // Key functions
+    virtual int handleKey(int key)
+    {
+        if (dataHstryBuf[0] || dataHstryBuf[1]) { // if at least 1 boat data type supports charts
+
+            // Set page mode: value | value/half chart | full charts
+            if (key == 1) {
+                switch (pageMode) {
+
+                case VALUES:
+
+                    if (dataHstryBuf[0]) {
+                        pageMode = VAL1_CHART;
+                    } else if (dataHstryBuf[1]) {
+                        pageMode = VAL2_CHART;
+                    }
+                    break;
+
+                case VAL1_CHART:
+
+                    if (dataHstryBuf[1]) {
+                        pageMode = VAL2_CHART;
+                    } else {
+                        pageMode = CHARTS;
+                    }
+                    break;
+
+                case VAL2_CHART:
+                    pageMode = CHARTS;
+                    break;
+
+                case CHARTS:
+                    pageMode = VALUES;
+                    break;
+                }
+                return 0; // Commit the key
+            }
+
+            // Set time frame to show for history chart
+#if defined BOARD_OBP60S3
+            if (key == 5) {
+#elif defined BOARD_OBP40S3
+            if (key == 2) {
+#endif
+                if (dataIntv == 1) {
+                    dataIntv = 2;
+                } else if (dataIntv == 2) {
+                    dataIntv = 3;
+                } else if (dataIntv == 3) {
+                    dataIntv = 4;
+                } else if (dataIntv == 4) {
+                    dataIntv = 8;
+                } else {
+                    dataIntv = 1;
+                }
+                return 0; // Commit the key
+            }
+        }
+
+        // Keylock function
+        if (key == 11) { // Code for keylock
             commonData->keylock = !commonData->keylock;
-            return 0;                   // Commit the key
+            return 0; // Commit the key
         }
         return key;
     }
 
-    int displayPage(PageData &pageData){
-        GwConfigHandler *config = commonData->config;
-        GwLog *logger = commonData->logger;
-
-        // Old values for hold function
-        static String svalue1old = "";
-        static String unit1old = "";
-        static String svalue2old = "";
-        static String unit2old = "";
-
-        // Get config data
-        String lengthformat = config->getString(config->lengthFormat);
-        // bool simulation = config->getBool(config->useSimuData);
-        bool holdvalues = config->getBool(config->holdvalues);
-        String flashLED = config->getString(config->flashLED);
-        String backlightMode = config->getString(config->backlight);
-        
-        // Get boat values #1
-        GwApi::BoatValue *bvalue1 = pageData.values[0]; // First element in list (only one value by PageOneValue)
-        String name1 = xdrDelete(bvalue1->getName());   // Value name
-        name1 = name1.substring(0, 6);                  // String length limit for value name
-        calibrationData.calibrateInstance(bvalue1, logger); // Check if boat data value is to be calibrated
-        double value1 = bvalue1->value;                 // Value as double in SI unit
-        bool valid1 = bvalue1->valid;                   // Valid information 
-        String svalue1 = formatValue(bvalue1, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
-        String unit1 = formatValue(bvalue1, *commonData).unit;        // Unit of value
-
-        // Get boat values #2
-        GwApi::BoatValue *bvalue2 = pageData.values[1]; // Second element in list
-        String name2 = xdrDelete(bvalue2->getName());   // Value name
-        name2 = name2.substring(0, 6);                  // String length limit for value name
-        calibrationData.calibrateInstance(bvalue2, logger); // Check if boat data value is to be calibrated
-        double value2 = bvalue2->value;                 // Value as double in SI unit
-        bool valid2 = bvalue2->valid;                   // Valid information 
-        String svalue2 = formatValue(bvalue2, *commonData).svalue;    // Formatted value as string including unit conversion and switching decimal places
-        String unit2 = formatValue(bvalue2, *commonData).unit;        // Unit of value
-
-        // Optical warning by limit violation (unused)
-        if(String(flashLED) == "Limit Violation"){
+    virtual void displayNew(PageData& pageData)
+    {
+#ifdef BOARD_OBP60S3
+        // Clear optical warning
+        if (flashLED == "Limit Violation") {
             setBlinkingLED(false);
-            setFlashLED(false); 
+            setFlashLED(false);
+        }
+#endif
+        // buffer initialization will fail, if page is default page, because <displayNew> is not executed at system start for default page
+        for (int i = 0; i < NUMVALUES; i++) {
+            if (!dataChart[i]) { // Create chart objects if they don't exist
+
+                GwApi::BoatValue* bValue = pageData.values[i]; // Page boat data element
+                String bValName = bValue->getName(); // Value name
+                String bValFormat = bValue->getFormat(); // Value format
+
+                dataHstryBuf[i] = pageData.hstryBuffers->getBuffer(bValName);
+
+                if (dataHstryBuf[i]) {
+                    dataChart[i].reset(new Chart(*dataHstryBuf[i], Chart::dfltChrtDta[bValFormat].range, *commonData, useSimuData));
+                    LOG_DEBUG(GwLog::DEBUG, "PageTwoValues: Created chart object%d for %s", i, bValName.c_str());
+                } else {
+                    LOG_DEBUG(GwLog::DEBUG, "PageTwoValues: No chart object available for %s", bValName.c_str());
+                }
+            }
         }
 
-        // Logging boat values
-        if (bvalue1 == NULL) return PAGE_OK; // WTF why this statement?
-        LOG_DEBUG(GwLog::LOG,"Drawing at PageTwoValues, %s: %f, %s: %f", name1.c_str(), value1, name2.c_str(), value2);
+        setupKeys(); // adjust <mode> key depending on chart supported boat data type
+    }
+
+    int displayPage(PageData& pageData)
+    {
+        LOG_DEBUG(GwLog::LOG, "Display PageTwoValues");
+
+        // Get boat values for page
+        std::vector<GwApi::BoatValue*> bValue;
+        bValue.push_back(pageData.values[0]); // Page boat data element 1
+        bValue.push_back(pageData.values[1]); // Page boat data element 2
+
+        // Optical warning by limit violation (unused)
+        if (String(flashLED) == "Limit Violation") {
+            setBlinkingLED(false);
+            setFlashLED(false);
+        }
+
+        if (bValue[0] == NULL && bValue[1] == NULL)
+            return PAGE_OK; // no data, no page to display
+
+        LOG_DEBUG(GwLog::DEBUG, "PageTwoValues: printing #1: %s, %.3f, #2: %s, %.3f",
+            bValue[0]->getName().c_str(), bValue[0]->value, bValue[1]->getName().c_str(), bValue[1]->value);
 
         // Draw page
         //***********************************************************
 
-        // Set display in partial refresh mode
-        getdisplay().setPartialWindow(0, 0, getdisplay().width(), getdisplay().height()); // Set partial update
+        getdisplay().setPartialWindow(0, 0, width, height); // Set partial update
 
-        // ############### Value 1 ################
+        if (pageMode == VALUES || (dataHstryBuf[0] == nullptr && dataHstryBuf[1] == nullptr)) {
+            // show only data value; ignore other pageMode options if no chart supported boat data history buffer is available
+            showData(bValue, FULL);
 
-        // Show name
-        getdisplay().setTextColor(commonData->fgcolor);
-        getdisplay().setFont(&Ubuntu_Bold20pt8b);
-        getdisplay().setCursor(20, 80);
-        getdisplay().print(name1);                           // Page name
+        } else if (pageMode == VAL1_CHART) { // show data value 1 and chart
+            showData({bValue[0]}, HALF);
+            if (dataChart[0]) {
+                dataChart[0]->showChrt(HORIZONTAL, HALF_SIZE_BOTTOM, dataIntv, NO_PRNT_NAME, NO_PRNT_VALUE, *bValue[0]);
+            }
 
-        // Show unit
-        getdisplay().setFont(&Ubuntu_Bold12pt8b);
-        getdisplay().setCursor(20, 130);
-        if(holdvalues == false){
-            getdisplay().print(unit1);                       // Unit
-        }
-        else{
-            getdisplay().print(unit1old);
-        }
+        } else if (pageMode == VAL2_CHART) { // show data value 2 and chart
+            showData({bValue[1]}, HALF);
+            if (dataChart[1]) {
+                dataChart[1]->showChrt(HORIZONTAL, HALF_SIZE_BOTTOM, dataIntv, NO_PRNT_NAME, NO_PRNT_VALUE, *bValue[1]);
+            }
 
-        // Switch font if format for any values
-        if(bvalue1->getFormat() == "formatLatitude" || bvalue1->getFormat() == "formatLongitude"){
-            getdisplay().setFont(&Ubuntu_Bold20pt8b);
-            getdisplay().setCursor(50, 130);
-        }
-        else if(bvalue1->getFormat() == "formatTime" || bvalue1->getFormat() == "formatDate"){
-            getdisplay().setFont(&Ubuntu_Bold20pt8b);
-            getdisplay().setCursor(170, 105);
-        }
-        else{
-            getdisplay().setFont(&DSEG7Classic_BoldItalic42pt7b);
-            getdisplay().setCursor(180, 130);
-        }
-
-        // Show bus data
-        if(holdvalues == false){
-            getdisplay().print(svalue1);                                     // Real value as formated string
-        }
-        else{
-            getdisplay().print(svalue1old);                                  // Old value as formated string
-        }
-        if(valid1 == true){
-            svalue1old = svalue1;                                       // Save the old value
-            unit1old = unit1;                                           // Save the old unit
-        }
-
-        // ############### Horizontal Line ################
-
-        // Horizontal line 3 pix
-        getdisplay().fillRect(0, 145, 400, 3, commonData->fgcolor);
-
-        // ############### Value 2 ################
-
-        // Show name
-        getdisplay().setFont(&Ubuntu_Bold20pt8b);
-        getdisplay().setCursor(20, 190);
-        getdisplay().print(name2);                           // Page name
-
-        // Show unit
-        getdisplay().setFont(&Ubuntu_Bold12pt8b);
-        getdisplay().setCursor(20, 240);
-        if(holdvalues == false){
-            getdisplay().print(unit2);                       // Unit
-        }
-        else{
-            getdisplay().print(unit2old);
-        }
-
-        // Switch font if format for any values
-        if(bvalue2->getFormat() == "formatLatitude" || bvalue2->getFormat() == "formatLongitude"){
-            getdisplay().setFont(&Ubuntu_Bold20pt8b);
-            getdisplay().setCursor(50, 240);
-        }
-        else if(bvalue2->getFormat() == "formatTime" || bvalue2->getFormat() == "formatDate"){
-            getdisplay().setFont(&Ubuntu_Bold20pt8b);
-            getdisplay().setCursor(170, 215);
-        }
-        else{
-            getdisplay().setFont(&DSEG7Classic_BoldItalic42pt7b);
-            getdisplay().setCursor(180, 240);
-        }
-
-        // Show bus data
-        if(holdvalues == false){
-            getdisplay().print(svalue2);                                     // Real value as formated string
-        }
-        else{
-            getdisplay().print(svalue2old);                                  // Old value as formated string
-        }
-        if(valid2 == true){
-            svalue2old = svalue2;                                       // Save the old value
-            unit2old = unit2;                                           // Save the old unit
+        } else if (pageMode == CHARTS) { // show both data charts
+            if (dataChart[0]) {
+                if (dataChart[1]) {
+                    dataChart[0]->showChrt(HORIZONTAL, HALF_SIZE_TOP, dataIntv, PRNT_NAME, PRNT_VALUE, *bValue[0]);
+                } else {
+                    dataChart[0]->showChrt(HORIZONTAL, FULL_SIZE, dataIntv, PRNT_NAME, PRNT_VALUE, *bValue[0]);
+                }
+            }
+            if (dataChart[1]) {
+                if (dataChart[0]) {
+                    dataChart[1]->showChrt(HORIZONTAL, HALF_SIZE_BOTTOM, dataIntv, PRNT_NAME, PRNT_VALUE, *bValue[1]);
+                } else {
+                    dataChart[1]->showChrt(HORIZONTAL, FULL_SIZE, dataIntv, PRNT_NAME, PRNT_VALUE, *bValue[1]);
+                }
+            }
         }
 
         return PAGE_UPDATE;
     };
 };
 
-static Page *createPage(CommonData &common){
+static Page* createPage(CommonData& common)
+{
     return new PageTwoValues(common);
 }
+
 /**
  * with the code below we make this page known to the PageTask
  * we give it a type (name) that can be selected in the config
@@ -181,10 +332,10 @@ static Page *createPage(CommonData &common){
  * this will be number of BoatValue pointers in pageData.values
  */
 PageDescription registerPageTwoValues(
-    "TwoValues",    // Page name
-    createPage,     // Action
-    2,              // Number of bus values depends on selection in Web configuration
-    true            // Show display header on/off
+    "TwoValues", // Page name
+    createPage, // Action
+    2, // Number of bus values depends on selection in Web configuration
+    true // Show display header on/off
 );
 
 #endif

--- a/lib/obp60task/PageWindPlot.cpp
+++ b/lib/obp60task/PageWindPlot.cpp
@@ -163,8 +163,6 @@ public:
         oldShowTruW = !showTruW; // Force chart update in displayPage
 #endif
 
-        // With chart object initialization being performed here, PageWindPlot won't properly work as default page,
-        // because <displayNew> is not executed at system start for default page
         if (!twdChart) { // Create true wind charts if they don't exist
             twdHstry = pageData.hstryBuffers->getBuffer("TWD");
             twsHstry = pageData.hstryBuffers->getBuffer("TWS");

--- a/lib/obp60task/PageWindPlot.cpp
+++ b/lib/obp60task/PageWindPlot.cpp
@@ -2,7 +2,6 @@
 
 #include "Pagedata.h"
 #include "OBP60Extensions.h"
-#include "OBPDataOperations.h"
 #include "OBPcharts.h"
 
 // ****************************************************************
@@ -77,9 +76,9 @@ public:
         commonData->keydata[0].label = "MODE";
 #if defined BOARD_OBP60S3
         commonData->keydata[1].label = "SRC";
-        commonData->keydata[4].label = "INTV";
+        commonData->keydata[4].label = "ZOOM";
 #elif defined BOARD_OBP40S3
-        commonData->keydata[1].label = "INTV";
+        commonData->keydata[1].label = "ZOOM";
 #endif
     }
 
@@ -209,14 +208,14 @@ public:
         getdisplay().setTextColor(commonData->fgcolor);
 
         if (chrtMode == 'D') {
-            wdFlChart->showChrt(dataIntv, *wdBVal);
+            wdFlChart->showChrt(dataIntv, *wdBVal, true);
 
         } else if (chrtMode == 'S') {
-            wsFlChart->showChrt(dataIntv, *wsBVal);
+            wsFlChart->showChrt(dataIntv, *wsBVal, true);
 
         } else if (chrtMode == 'B') {
-            wdHfChart->showChrt(dataIntv, *wdBVal);
-            wsHfChart->showChrt(dataIntv, *wsBVal);
+            wdHfChart->showChrt(dataIntv, *wdBVal, true);
+            wsHfChart->showChrt(dataIntv, *wsBVal, true);
         }
 
         LOG_DEBUG(GwLog::DEBUG, "PageWindPlot: page time %ldms", millis() - pageTime);

--- a/lib/obp60task/PageWindPlot.cpp
+++ b/lib/obp60task/PageWindPlot.cpp
@@ -11,6 +11,15 @@ class PageWindPlot : public Page {
 private:
     GwLog* logger;
 
+    static constexpr char SHOW_WIND_DIR = 'D';
+    static constexpr char SHOW_WIND_SPEED = 'S';
+    static constexpr char SHOW_BOTH = 'B';
+    static constexpr char HORIZONTAL = 'H';
+    static constexpr char VERTICAL = 'V';
+    static constexpr int8_t FULL_SIZE = 0;
+    static constexpr int8_t HALF_SIZE_TOP = 1;
+    static constexpr int8_t HALF_SIZE_BOTTOM = 2;
+
     int width; // Screen width
     int height; // Screen height
 
@@ -37,16 +46,12 @@ private:
     RingBuffer<uint16_t>* awsHstry = nullptr;
 
     // Chart objects
-    std::unique_ptr<Chart<uint16_t>> twdFlChart, awdFlChart; // Chart object for wind direction, full size
-    std::unique_ptr<Chart<uint16_t>> twsFlChart, awsFlChart; // Chart object for wind speed, full size
-    std::unique_ptr<Chart<uint16_t>> twdHfChart, awdHfChart; // Chart object for wind direction, half size
-    std::unique_ptr<Chart<uint16_t>> twsHfChart, awsHfChart; // Chart object for wind speed, half size
+    std::unique_ptr<Chart> twdChart, awdChart; // Chart object for wind direction, full size
+    std::unique_ptr<Chart> twsChart, awsChart; // Chart object for wind speed, full size
 
     // Active charts and values
-    Chart<uint16_t>* wdFlChart = nullptr;
-    Chart<uint16_t>* wsFlChart = nullptr;
-    Chart<uint16_t>* wdHfChart = nullptr;
-    Chart<uint16_t>* wsHfChart = nullptr;
+    Chart* wdChart = nullptr;
+    Chart* wsChart = nullptr;
     GwApi::BoatValue* wdBVal = nullptr;
     GwApi::BoatValue* wsBVal = nullptr;
 
@@ -86,12 +91,12 @@ public:
     {
         // Set chart mode TWD | TWS
         if (key == 1) {
-            if (chrtMode == 'D') {
-                chrtMode = 'S';
-            } else if (chrtMode == 'S') {
-                chrtMode = 'B';
+            if (chrtMode == SHOW_WIND_DIR) {
+                chrtMode = SHOW_WIND_SPEED;
+            } else if (chrtMode == SHOW_WIND_SPEED) {
+                chrtMode = SHOW_BOTH;
             } else {
-                chrtMode = 'D';
+                chrtMode = SHOW_WIND_DIR;
             }
             return 0; // Commit the key
         }
@@ -150,39 +155,36 @@ public:
         oldShowTruW = !showTruW; // Force chart update in displayPage
 #endif
 
-        // buffer initialization cannot be performed here, because <displayNew> is not executed at system start for default page
-        /* if (!twdFlChart) { // Create true wind charts if they don't exist
+        // With chart object initialization being performed here, PageWindPlot won't properly work as default page,
+        // because <displayNew> is not executed at system start for default page
+        if (!twdChart) { // Create true wind charts if they don't exist
             twdHstry = pageData.hstryBuffers->getBuffer("TWD");
             twsHstry = pageData.hstryBuffers->getBuffer("TWS");
 
             if (twdHstry) {
-                twdFlChart.reset(new Chart<uint16_t>(*twdHstry, 'V', 0, dfltRngWd, *commonData, useSimuData));
-                twdHfChart.reset(new Chart<uint16_t>(*twdHstry, 'V', 1, dfltRngWd, *commonData, useSimuData));
+                twdChart.reset(new Chart(*twdHstry, Chart::dfltChrtDta["formatCourse"].range, *commonData, useSimuData));
             }
             if (twsHstry) {
-                twsFlChart.reset(new Chart<uint16_t>(*twsHstry, 'H', 0, dfltRngWs, *commonData, useSimuData));
-                twsHfChart.reset(new Chart<uint16_t>(*twsHstry, 'V', 2, dfltRngWs, *commonData, useSimuData));
+                twsChart.reset(new Chart(*twsHstry, Chart::dfltChrtDta["formatKnots"].range, *commonData, useSimuData));
             }
         }
 
-        if (!awdFlChart) { // Create apparent wind charts if they don't exist
+        if (!awdChart) { // Create apparent wind charts if they don't exist
             awdHstry = pageData.hstryBuffers->getBuffer("AWD");
             awsHstry = pageData.hstryBuffers->getBuffer("AWS");
 
             if (awdHstry) {
-                awdFlChart.reset(new Chart<uint16_t>(*awdHstry, 'V', 0, dfltRngWd, *commonData, useSimuData));
-                awdHfChart.reset(new Chart<uint16_t>(*awdHstry, 'V', 1, dfltRngWd, *commonData, useSimuData));
+                awdChart.reset(new Chart(*awdHstry, Chart::dfltChrtDta["formatCourse"].range, *commonData, useSimuData));
             }
             if (awsHstry) {
-                awsFlChart.reset(new Chart<uint16_t>(*awsHstry, 'H', 0, dfltRngWs, *commonData, useSimuData));
-                awsHfChart.reset(new Chart<uint16_t>(*awsHstry, 'V', 2, dfltRngWs, *commonData, useSimuData));
+                awsChart.reset(new Chart(*awsHstry, Chart::dfltChrtDta["formatKnots"].range, *commonData, useSimuData));
             }
             if (twdHstry && twsHstry && awdHstry && awsHstry) {
                 LOG_DEBUG(GwLog::DEBUG, "PageWindPlot: Created wind charts");
             } else {
                 LOG_DEBUG(GwLog::DEBUG, "PageWindPlot: Some/all chart objects for wind data missing");
             }
-        } */
+        }
     }
 
     int displayPage(PageData& pageData)
@@ -190,54 +192,46 @@ public:
         LOG_DEBUG(GwLog::LOG, "Display PageWindPlot");
         ulong pageTime = millis();
 
-        if (!twdFlChart) { // Create true wind charts if they don't exist
-            twdHstry = pageData.hstryBuffers->getBuffer("TWD");
-            twsHstry = pageData.hstryBuffers->getBuffer("TWS");
+        /*        if (!twdChart) { // Create true wind charts if they don't exist
+                    twdHstry = pageData.hstryBuffers->getBuffer("TWD");
+                    twsHstry = pageData.hstryBuffers->getBuffer("TWS");
 
-            if (twdHstry) {
-                twdFlChart.reset(new Chart<uint16_t>(*twdHstry, 'V', 0, Chart<uint16_t>::dfltChrtDta["formatCourse"].range, *commonData, useSimuData));
-                twdHfChart.reset(new Chart<uint16_t>(*twdHstry, 'V', 1, Chart<uint16_t>::dfltChrtDta["formatCourse"].range, *commonData, useSimuData));
-            }
-            if (twsHstry) {
-                twsFlChart.reset(new Chart<uint16_t>(*twsHstry, 'H', 0, Chart<uint16_t>::dfltChrtDta["formatKnots"].range, *commonData, useSimuData));
-                twsHfChart.reset(new Chart<uint16_t>(*twsHstry, 'V', 2, Chart<uint16_t>::dfltChrtDta["formatKnots"].range, *commonData, useSimuData));
-            }
-        }
+                    if (twdHstry) {
+                        twdChart.reset(new Chart(*twdHstry, Chart::dfltChrtDta["formatCourse"].range, *commonData, useSimuData));
+                    }
+                    if (twsHstry) {
+                        twsChart.reset(new Chart(*twsHstry, Chart::dfltChrtDta["formatKnots"].range, *commonData, useSimuData));
+                    }
+                }
 
-        if (!awdFlChart) { // Create apparent wind charts if they don't exist
-            awdHstry = pageData.hstryBuffers->getBuffer("AWD");
-            awsHstry = pageData.hstryBuffers->getBuffer("AWS");
+                if (!awdChart) { // Create apparent wind charts if they don't exist
+                    awdHstry = pageData.hstryBuffers->getBuffer("AWD");
+                    awsHstry = pageData.hstryBuffers->getBuffer("AWS");
 
-            if (awdHstry) {
-                awdFlChart.reset(new Chart<uint16_t>(*awdHstry, 'V', 0, Chart<uint16_t>::dfltChrtDta["formatCourse"].range, *commonData, useSimuData));
-                awdHfChart.reset(new Chart<uint16_t>(*awdHstry, 'V', 1, Chart<uint16_t>::dfltChrtDta["formatCourse"].range, *commonData, useSimuData));
-            }
-            if (awsHstry) {
-                awsFlChart.reset(new Chart<uint16_t>(*awsHstry, 'H', 0, Chart<uint16_t>::dfltChrtDta["formatKnots"].range, *commonData, useSimuData));
-                awsHfChart.reset(new Chart<uint16_t>(*awsHstry, 'V', 2, Chart<uint16_t>::dfltChrtDta["formatKnots"].range, *commonData, useSimuData));
-            }
-            if (twdHstry && twsHstry && awdHstry && awsHstry) {
-                LOG_DEBUG(GwLog::DEBUG, "PageWindPlot: Created wind charts");
-            } else {
-                LOG_DEBUG(GwLog::DEBUG, "PageWindPlot: Some/all chart objects for wind data missing");
-            }
-        }
+                    if (awdHstry) {
+                        awdChart.reset(new Chart(*awdHstry, Chart::dfltChrtDta["formatCourse"].range, *commonData, useSimuData));
+                    }
+                    if (awsHstry) {
+                        awsChart.reset(new Chart(*awsHstry, Chart::dfltChrtDta["formatKnots"].range, *commonData, useSimuData));
+                    }
+                    if (twdHstry && twsHstry && awdHstry && awsHstry) {
+                        LOG_DEBUG(GwLog::DEBUG, "PageWindPlot: Created wind charts");
+                    } else {
+                        LOG_DEBUG(GwLog::DEBUG, "PageWindPlot: Some/all chart objects for wind data missing");
+                    }
+                } */
 
         if (showTruW != oldShowTruW) {
 
             // Switch active charts based on showTruW
             if (showTruW) {
-                wdFlChart = twdFlChart.get();
-                wsFlChart = twsFlChart.get();
-                wdHfChart = twdHfChart.get();
-                wsHfChart = twsHfChart.get();
+                wdChart = twdChart.get();
+                wsChart = twsChart.get();
                 wdBVal = pageData.values[0];
                 wsBVal = pageData.values[1];
             } else {
-                wdFlChart = awdFlChart.get();
-                wsFlChart = awsFlChart.get();
-                wdHfChart = awdHfChart.get();
-                wsHfChart = awsHfChart.get();
+                wdChart = awdChart.get();
+                wsChart = awsChart.get();
                 wdBVal = pageData.values[2];
                 wsBVal = pageData.values[3];
             }
@@ -253,22 +247,22 @@ public:
         getdisplay().setPartialWindow(0, 0, width, height); // Set partial update
         getdisplay().setTextColor(commonData->fgcolor);
 
-        if (chrtMode == 'D') {
-            if (wdFlChart) {
-                wdFlChart->showChrt(*wdBVal, dataIntv, true);
+        if (chrtMode == SHOW_WIND_DIR) {
+            if (wdChart) {
+                wdChart->showChrt(VERTICAL, FULL_SIZE, dataIntv, true, *wdBVal);
             }
 
-        } else if (chrtMode == 'S') {
-            if (wsFlChart) {
-                wsFlChart->showChrt(*wsBVal, dataIntv, true);
+        } else if (chrtMode == SHOW_WIND_SPEED) {
+            if (wsChart) {
+                wsChart->showChrt(HORIZONTAL, FULL_SIZE, dataIntv, true, *wsBVal);
             }
 
-        } else if (chrtMode == 'B') {
-            if (wdHfChart) {
-                wdHfChart->showChrt(*wdBVal, dataIntv, true);
+        } else if (chrtMode == SHOW_BOTH) {
+            if (wdChart) {
+                wdChart->showChrt(VERTICAL, HALF_SIZE_TOP, dataIntv, true, *wdBVal);
             }
-            if (wsHfChart) {
-                wsHfChart->showChrt(*wsBVal, dataIntv, true);
+            if (wsChart) {
+                wsChart->showChrt(VERTICAL, HALF_SIZE_BOTTOM, dataIntv, true, *wsBVal);
             }
         }
 

--- a/lib/obp60task/PageWindPlot.cpp
+++ b/lib/obp60task/PageWindPlot.cpp
@@ -22,7 +22,7 @@ private:
     int dataIntv = 1; // Update interval for wind history chart:
                       // (1)|(2)|(3)|(4)|(8) x 240 seconds for 4, 8, 12, 16, 32 min. history chart
     bool useSimuData;
-    //bool holdValues;
+    // bool holdValues;
     String flashLED;
     String backlightMode;
 
@@ -65,7 +65,7 @@ public:
 
         // Get config data
         useSimuData = common.config->getBool(common.config->useSimuData);
-        //holdValues = common.config->getBool(common.config->holdvalues);
+        // holdValues = common.config->getBool(common.config->holdvalues);
         flashLED = common.config->getString(common.config->flashLED);
         backlightMode = common.config->getString(common.config->backlight);
 
@@ -143,6 +143,7 @@ public:
         }
 #endif
 #ifdef BOARD_OBP40S3
+        // we can only initialize user defined wind source here, because "pageData" is not available at object instantiation
         wndSrc = commonData->config->getString("page" + String(pageData.pageNumber) + "wndsrc");
         if (wndSrc == "True wind") {
             showTruW = true;
@@ -151,8 +152,8 @@ public:
         }
         oldShowTruW = !showTruW; // Force chart update in displayPage
 #endif
-        // buffer initialization cannot be performed here, because <displayNew> is not executed at system start for default page
 
+        // buffer initialization cannot be performed here, because <displayNew> is not executed at system start for default page
         /* if (!twdFlChart) { // Create true wind charts if they don't exist
             twdHstry = pageData.hstryBuffers->getBuffer("TWD");
             twsHstry = pageData.hstryBuffers->getBuffer("TWS");
@@ -257,20 +258,20 @@ public:
 
         if (chrtMode == 'D') {
             if (wdFlChart) {
-                wdFlChart->showChrt(dataIntv, *wdBVal, true);
+                wdFlChart->showChrt(*wdBVal, dataIntv, true);
             }
 
         } else if (chrtMode == 'S') {
             if (wsFlChart) {
-                wsFlChart->showChrt(dataIntv, *wsBVal, true);
+                wsFlChart->showChrt(*wsBVal, dataIntv, true);
             }
 
         } else if (chrtMode == 'B') {
             if (wdHfChart) {
-                wdHfChart->showChrt(dataIntv, *wdBVal, true);
+                wdHfChart->showChrt(*wdBVal, dataIntv, true);
             }
             if (wsHfChart) {
-                wsHfChart->showChrt(dataIntv, *wsBVal, true);
+                wsHfChart->showChrt(*wsBVal, dataIntv, true);
             }
         }
 

--- a/lib/obp60task/PageWindPlot.cpp
+++ b/lib/obp60task/PageWindPlot.cpp
@@ -167,12 +167,13 @@ public:
                 LOG_DEBUG(GwLog::DEBUG, "PageWindPlot: Creating true wind charts");                
                 auto* twdHstry = pageData.hstryManager->getBuffer("TWD");
                 auto* twsHstry = pageData.hstryManager->getBuffer("TWS");
-                twdFlChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*twdHstry, 1, 0, dfltRngWd, *commonData, useSimuData));
-                twsFlChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*twsHstry, 0, 0, dfltRngWs, *commonData, useSimuData));
-                twdHfChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*twdHstry, 1, 1, dfltRngWd, *commonData, useSimuData));
-                twsHfChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*twsHstry, 1, 2, dfltRngWs, *commonData, useSimuData));
-                // twdHfChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*twdHstry, 0, 1, dfltRngWd, *commonData, useSimuData));
-                // twsHfChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*twsHstry, 0, 2, dfltRngWs, *commonData, useSimuData));
+
+                twdFlChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*twdHstry, 'V', 0, dfltRngWd, *commonData, useSimuData));
+                twsFlChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*twsHstry, 'H', 0, dfltRngWs, *commonData, useSimuData));
+                twdHfChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*twdHstry, 'V', 1, dfltRngWd, *commonData, useSimuData));
+                twsHfChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*twsHstry, 'V', 2, dfltRngWs, *commonData, useSimuData));
+                // twdHfChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*twdHstry, 'H', 1, dfltRngWd, *commonData, useSimuData));
+                // twsHfChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*twsHstry, 'H', 2, dfltRngWs, *commonData, useSimuData));
                 // LOG_DEBUG(GwLog::DEBUG, "PageWindPlot: twdHstry: %p, twsHstry: %p", (void*)twdHstry, (void*)twsHstry);
             }
 
@@ -181,10 +182,10 @@ public:
                 auto* awdHstry = pageData.hstryManager->getBuffer("AWD");
                 auto* awsHstry = pageData.hstryManager->getBuffer("AWS");
 
-                awdFlChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*awdHstry, 1, 0, dfltRngWd, *commonData, useSimuData));
-                awsFlChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*awsHstry, 0, 0, dfltRngWs, *commonData, useSimuData));
-                awdHfChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*awdHstry, 1, 1, dfltRngWd, *commonData, useSimuData));
-                awsHfChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*awsHstry, 1, 2, dfltRngWs, *commonData, useSimuData));
+                awdFlChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*awdHstry, 'V', 0, dfltRngWd, *commonData, useSimuData));
+                awsFlChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*awsHstry, 'H', 0, dfltRngWs, *commonData, useSimuData));
+                awdHfChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*awdHstry, 'V', 1, dfltRngWd, *commonData, useSimuData));
+                awsHfChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*awsHstry, 'V', 2, dfltRngWs, *commonData, useSimuData));
             }
             
             // Switch active charts based on showTruW

--- a/lib/obp60task/PageWindPlot.cpp
+++ b/lib/obp60task/PageWindPlot.cpp
@@ -19,8 +19,8 @@ private:
     bool showTruW = true; // Show true wind or apparent wind in chart area
     bool oldShowTruW = false; // remember recent user selection of wind data type
 
-    int dataIntv = 1; // Update interval for wind history chart:
-                      // (1)|(2)|(3)|(4)|(8) x 240 seconds for 4, 8, 12, 16, 32 min. history chart
+    int8_t dataIntv = 1; // Update interval for wind history chart:
+                         // (1)|(2)|(3)|(4)|(8) x 240 seconds for 4, 8, 12, 16, 32 min. history chart
     bool useSimuData;
     // bool holdValues;
     String flashLED;
@@ -49,9 +49,6 @@ private:
     Chart<uint16_t>* wsHfChart = nullptr;
     GwApi::BoatValue* wdBVal = nullptr;
     GwApi::BoatValue* wsBVal = nullptr;
-
-    const double dfltRngWd = 60.0 * DEG_TO_RAD; // default range for course chart from min to max value in RAD
-    const double dfltRngWs = 7.5; // default range for wind speed chart from min to max value in m/s
 
 public:
     PageWindPlot(CommonData& common)
@@ -198,12 +195,12 @@ public:
             twsHstry = pageData.hstryBuffers->getBuffer("TWS");
 
             if (twdHstry) {
-                twdFlChart.reset(new Chart<uint16_t>(*twdHstry, 'V', 0, dfltRngWd, *commonData, useSimuData));
-                twdHfChart.reset(new Chart<uint16_t>(*twdHstry, 'V', 1, dfltRngWd, *commonData, useSimuData));
+                twdFlChart.reset(new Chart<uint16_t>(*twdHstry, 'V', 0, Chart<uint16_t>::dfltChrtDta["formatCourse"].range, *commonData, useSimuData));
+                twdHfChart.reset(new Chart<uint16_t>(*twdHstry, 'V', 1, Chart<uint16_t>::dfltChrtDta["formatCourse"].range, *commonData, useSimuData));
             }
             if (twsHstry) {
-                twsFlChart.reset(new Chart<uint16_t>(*twsHstry, 'H', 0, dfltRngWs, *commonData, useSimuData));
-                twsHfChart.reset(new Chart<uint16_t>(*twsHstry, 'V', 2, dfltRngWs, *commonData, useSimuData));
+                twsFlChart.reset(new Chart<uint16_t>(*twsHstry, 'H', 0, Chart<uint16_t>::dfltChrtDta["formatKnots"].range, *commonData, useSimuData));
+                twsHfChart.reset(new Chart<uint16_t>(*twsHstry, 'V', 2, Chart<uint16_t>::dfltChrtDta["formatKnots"].range, *commonData, useSimuData));
             }
         }
 
@@ -212,12 +209,12 @@ public:
             awsHstry = pageData.hstryBuffers->getBuffer("AWS");
 
             if (awdHstry) {
-                awdFlChart.reset(new Chart<uint16_t>(*awdHstry, 'V', 0, dfltRngWd, *commonData, useSimuData));
-                awdHfChart.reset(new Chart<uint16_t>(*awdHstry, 'V', 1, dfltRngWd, *commonData, useSimuData));
+                awdFlChart.reset(new Chart<uint16_t>(*awdHstry, 'V', 0, Chart<uint16_t>::dfltChrtDta["formatCourse"].range, *commonData, useSimuData));
+                awdHfChart.reset(new Chart<uint16_t>(*awdHstry, 'V', 1, Chart<uint16_t>::dfltChrtDta["formatCourse"].range, *commonData, useSimuData));
             }
             if (awsHstry) {
-                awsFlChart.reset(new Chart<uint16_t>(*awsHstry, 'H', 0, dfltRngWs, *commonData, useSimuData));
-                awsHfChart.reset(new Chart<uint16_t>(*awsHstry, 'V', 2, dfltRngWs, *commonData, useSimuData));
+                awsFlChart.reset(new Chart<uint16_t>(*awsHstry, 'H', 0, Chart<uint16_t>::dfltChrtDta["formatKnots"].range, *commonData, useSimuData));
+                awsHfChart.reset(new Chart<uint16_t>(*awsHstry, 'V', 2, Chart<uint16_t>::dfltChrtDta["formatKnots"].range, *commonData, useSimuData));
             }
             if (twdHstry && twsHstry && awdHstry && awsHstry) {
                 LOG_DEBUG(GwLog::DEBUG, "PageWindPlot: Created wind charts");

--- a/lib/obp60task/PageWindPlot.cpp
+++ b/lib/obp60task/PageWindPlot.cpp
@@ -2,6 +2,7 @@
 
 #include "Pagedata.h"
 #include "OBP60Extensions.h"
+#include "OBPDataOperations.h"
 #include "OBPcharts.h"
 
 // ****************************************************************
@@ -163,12 +164,9 @@ public:
         if (showTruW != oldShowTruW) {
             if (!twdFlChart) { // Create true wind charts if they don't exist
 
-                LOG_DEBUG(GwLog::DEBUG, "PageWindPlot: Creating true wind charts");
-                auto* twdHstry = pageData.boatHstry->hstryBufList.twdHstry;
-                auto* twsHstry = pageData.boatHstry->hstryBufList.twsHstry;
-                // LOG_DEBUG(GwLog::DEBUG,"History Buffer addresses PageWindPlot: twdBuf: %p, twsBuf: %p", (void*)pageData.boatHstry->hstryBufList.twdHstry,
-                //     (void*)pageData.boatHstry->hstryBufList.twsHstry);
-
+                LOG_DEBUG(GwLog::DEBUG, "PageWindPlot: Creating true wind charts");                
+                auto* twdHstry = pageData.hstryManager->getBuffer("TWD");
+                auto* twsHstry = pageData.hstryManager->getBuffer("TWS");
                 twdFlChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*twdHstry, 1, 0, dfltRngWd, *commonData, useSimuData));
                 twsFlChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*twsHstry, 0, 0, dfltRngWs, *commonData, useSimuData));
                 twdHfChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*twdHstry, 1, 1, dfltRngWd, *commonData, useSimuData));
@@ -180,8 +178,8 @@ public:
 
             if (!awdFlChart) { // Create apparent wind charts if they don't exist
                 LOG_DEBUG(GwLog::DEBUG, "PageWindPlot: Creating apparent wind charts");
-                auto* awdHstry = pageData.boatHstry->hstryBufList.awdHstry;
-                auto* awsHstry = pageData.boatHstry->hstryBufList.awsHstry;
+                auto* awdHstry = pageData.hstryManager->getBuffer("AWD");
+                auto* awsHstry = pageData.hstryManager->getBuffer("AWS");
 
                 awdFlChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*awdHstry, 1, 0, dfltRngWd, *commonData, useSimuData));
                 awsFlChart = std::unique_ptr<Chart<uint16_t>>(new Chart<uint16_t>(*awsHstry, 0, 0, dfltRngWs, *commonData, useSimuData));
@@ -191,15 +189,15 @@ public:
             
             // Switch active charts based on showTruW
             if (showTruW) {
-                wdHstry = pageData.boatHstry->hstryBufList.twdHstry;
-                wsHstry = pageData.boatHstry->hstryBufList.twsHstry;
+                wdHstry = pageData.hstryManager->getBuffer("TWD");
+                wsHstry = pageData.hstryManager->getBuffer("TWS");
                 wdFlChart = twdFlChart.get();
                 wsFlChart = twsFlChart.get();
                 wdHfChart = twdHfChart.get();
                 wsHfChart = twsHfChart.get();
             } else {
-                wdHstry = pageData.boatHstry->hstryBufList.awdHstry;
-                wsHstry = pageData.boatHstry->hstryBufList.awsHstry;
+                wdHstry = pageData.hstryManager->getBuffer("AWD");
+                wsHstry = pageData.hstryManager->getBuffer("AWS");
                 wdFlChart = awdFlChart.get();
                 wsFlChart = awsFlChart.get();
                 wdHfChart = awdHfChart.get();

--- a/lib/obp60task/Pagedata.h
+++ b/lib/obp60task/Pagedata.h
@@ -204,3 +204,6 @@ typedef struct{
 
 // Formatter for boat values
 FormattedData formatValue(GwApi::BoatValue *value, CommonData &commondata);
+
+// Helper method for conversion of any data value from SI to user defined format (defined in OBP60Formatter)
+double convertValue(const double &value, const String &format, CommonData &commondata);

--- a/lib/obp60task/Pagedata.h
+++ b/lib/obp60task/Pagedata.h
@@ -16,7 +16,7 @@ typedef struct{
   uint8_t pageNumber; // page number in sequence of visible pages
   //the values will always contain the user defined values first
   ValueList values;
-  HstryManager* hstryManager;
+  HstryBuffers* hstryBuffers; // list of all boat history buffers
 } PageData;
 
 // Sensor data structure (only for extended sensors, not for NMEA bus sensors)

--- a/lib/obp60task/Pagedata.h
+++ b/lib/obp60task/Pagedata.h
@@ -4,11 +4,12 @@
 #include <functional>
 #include <vector>
 #include "LedSpiTask.h"
-#include "OBPDataOperations.h"
 
 #define MAX_PAGE_NUMBER 10    // Max number of pages for show data
 
 typedef std::vector<GwApi::BoatValue *> ValueList;
+
+class HstryBuffers;
 
 typedef struct{
   GwApi *api;

--- a/lib/obp60task/Pagedata.h
+++ b/lib/obp60task/Pagedata.h
@@ -16,7 +16,7 @@ typedef struct{
   uint8_t pageNumber; // page number in sequence of visible pages
   //the values will always contain the user defined values first
   ValueList values;
-  HstryBuf* boatHstry;
+  HstryManager* hstryManager;
 } PageData;
 
 // Sensor data structure (only for extended sensors, not for NMEA bus sensors)

--- a/lib/obp60task/Pagedata.h
+++ b/lib/obp60task/Pagedata.h
@@ -204,9 +204,8 @@ typedef struct{
 
 // Formatter for boat values
 FormattedData formatValue(GwApi::BoatValue *value, CommonData &commondata);
+FormattedData formatValue(GwApi::BoatValue *value, CommonData &commondata, bool ignoreSimuDataSetting);
 
 // Helper method for conversion of any data value from SI to user defined format (defined in OBP60Formatter)
 double convertValue(const double &value, const String &format, CommonData &commondata);
 double convertValue(const double &value, const String &name, const String &format, CommonData &commondata);
-// Helper method for conversion of boat data values from user defined format to SI (defined in OBP60Formatter)
-double convertToSItemp(const double &value, const String &name, const String &format, CommonData &commondata);

--- a/lib/obp60task/Pagedata.h
+++ b/lib/obp60task/Pagedata.h
@@ -207,3 +207,6 @@ FormattedData formatValue(GwApi::BoatValue *value, CommonData &commondata);
 
 // Helper method for conversion of any data value from SI to user defined format (defined in OBP60Formatter)
 double convertValue(const double &value, const String &format, CommonData &commondata);
+double convertValue(const double &value, const String &name, const String &format, CommonData &commondata);
+// Helper method for conversion of boat data values from user defined format to SI (defined in OBP60Formatter)
+double convertToSItemp(const double &value, const String &name, const String &format, CommonData &commondata);

--- a/lib/obp60task/obp60task.cpp
+++ b/lib/obp60task/obp60task.cpp
@@ -815,7 +815,7 @@ void OBP60Task(GwApi *api){
                     trueWind.addWinds();
                 }
                 // Handle history buffers for certain boat data for windplot page and other usage
-                 hstryBufList.handleHstryBufs(useSimuData);
+                 hstryBufList.handleHstryBufs(useSimuData, commonData);
 
                 // Clear display
                 // getdisplay().fillRect(0, 0, getdisplay().width(), getdisplay().height(), commonData.bgcolor);

--- a/lib/obp60task/obp60task.cpp
+++ b/lib/obp60task/obp60task.cpp
@@ -812,7 +812,7 @@ void OBP60Task(GwApi *api){
                 api->getStatus(commonData.status);
 
                 if (calcTrueWnds) {
-                    trueWind.addTrueWind();
+                    trueWind.addWinds();
                 }
                 // Handle history buffers for certain boat data for windplot page and other usage
                  hstryBufList.handleHstryBufs(useSimuData);


### PR DESCRIPTION
This pull request includes some new functionality and a lot of code rework. It replaces and includes closed PR #214:
- Boat data history buffer now work for basically any boat data type
- Chart plot code now supports graphical charts for more OBP pages and for multiple boat data types
- Heavy rework on chart plot code
- PageOneValue can show graphical charts for boat data
- PageTwoValues can show graphical charts for boat data
- PageWindPlot code has been optimized
- OBP60Formatter got added helper functions for numerical data conversion
- OBP60Formatter got overloaded function call to disable simulation data generation while preserving data conversion