### PR TITLE
Fix Wifi AP shutdown during client WiFi reconnect attempt

### DIFF
--- a/lib/gwwifi/GwWifi.cpp
+++ b/lib/gwwifi/GwWifi.cpp
@@ -143,29 +143,33 @@ void GwWifi::loop(){
 
                 delay(300);
 
-                if (acquireMutex()){
-                    esp_err_t stopErr=esp_wifi_stop();
-                    releaseMutex();
-                    if (stopErr != ESP_OK){
-                        LOG_DEBUG(GwLog::ERROR,"GwWifi: esp_wifi_stop failed: %d",(int)stopErr);
+                if (!apActive) {
+                    if (acquireMutex()){
+                        esp_err_t stopErr=esp_wifi_stop();
+                        releaseMutex();
+                        if (stopErr != ESP_OK){
+                            LOG_DEBUG(GwLog::ERROR,"GwWifi: esp_wifi_stop failed: %d",(int)stopErr);
+                        }
                     }
-                }
-                else{
-                    LOG_DEBUG(GwLog::ERROR,"GwWifi: mutex timeout in loop (stop)");
-                }
-
-                delay(100);
-
-                if (acquireMutex()){
-                    esp_err_t startErr=esp_wifi_start();
-                    releaseMutex();
-                    if (startErr != ESP_OK){
-                        LOG_DEBUG(GwLog::ERROR,"GwWifi: esp_wifi_start failed: %d",(int)startErr);
+                    else{
+                        LOG_DEBUG(GwLog::ERROR,"GwWifi: mutex timeout in loop (stop)");
                     }
+
+                    delay(100);
+
+                    if (acquireMutex()){
+                        esp_err_t startErr=esp_wifi_start();
+                        releaseMutex();
+                        if (startErr != ESP_OK){
+                            LOG_DEBUG(GwLog::ERROR,"GwWifi: esp_wifi_start failed: %d",(int)startErr);
+                        }
+                        connectInternal();
+                    }
+                    else{
+                        LOG_DEBUG(GwLog::ERROR,"GwWifi: mutex timeout in loop (start)");
+                    }
+                } else {
                     connectInternal();
-                }
-                else{
-                    LOG_DEBUG(GwLog::ERROR,"GwWifi: mutex timeout in loop (start)");
                 }
             }
         }


### PR DESCRIPTION
This fixes the error described in issue #237.
It prevents the restart of the wifi stack as long as an access point is still active. In this case, only a "connectInternal()" is performed.
