### PR TITLE
Adjust layout of PageSixValues for 4-digit pressure and long names+units

### DIFF
--- a/lib/obp60task/PageSixValues.cpp
+++ b/lib/obp60task/PageSixValues.cpp
@@ -6,7 +6,8 @@
 const int SixValues_x1 = 5;
 const int SixValues_DeltaX = 200;
 
-const int SixValues_y1 = 23;
+// const int SixValues_y1 = 23;
+const int SixValues_y1 = 22;
 const int SixValues_DeltaY = 83;
 
 const int HowManyValues = 6;
@@ -96,39 +97,38 @@ class PageSixValues : public Page
     
             // Show unit
                     getdisplay().setFont(&Ubuntu_Bold8pt8b);
-                    getdisplay().setCursor(x0, y0+72);
                     if(holdvalues == false){
-                        getdisplay().print(DataUnits[ValueIndex]);                       // Unit
+                        drawTextRalign(x0+187, y0+19, DataUnits[ValueIndex]);          // Unit
                         }
                     else{
-                        getdisplay().print(OldDataUnits[ValueIndex]);
+                        drawTextRalign(x0+187, y0+19, OldDataUnits[ValueIndex]);
                         }
     
-            // Switch font if format for any values
+            // Switch font depending on data type
                     if(DataFormat[ValueIndex] == "formatLatitude" || DataFormat[ValueIndex] == "formatLongitude"){
                         getdisplay().setFont(&Ubuntu_Bold12pt8b);
-                        getdisplay().setCursor(x0+10, y0+60);
+                        getdisplay().setCursor(x0+21, y0+60);
                         }
                     else if(DataFormat[ValueIndex] == "formatTime" || DataFormat[ValueIndex] == "formatDate"){
                         getdisplay().setFont(&Ubuntu_Bold16pt8b);
-                        getdisplay().setCursor(x0+20,y0+55);
+                        getdisplay().setCursor(x0+23,y0+55);
                         } 
             // pressure in hPa          
                     else if(DataFormat[ValueIndex] == "formatXdr:P:P"){
                         getdisplay().setFont(&DSEG7Classic_BoldItalic26pt7b);
-                        getdisplay().setCursor(x0+5, y0+70);
+                        getdisplay().setCursor(x0+23, y0+79);
                      }
             // RPM
                      else if(DataFormat[ValueIndex] == "formatXdr:T:R"){
                         getdisplay().setFont(&DSEG7Classic_BoldItalic16pt7b);
-                        getdisplay().setCursor(x0+25, y0+70);
+                        getdisplay().setCursor(x0+23, y0+79);
                      }
                     else{
                         getdisplay().setFont(&DSEG7Classic_BoldItalic26pt7b);
                         if ( DataText[ValueIndex][0] == '-' )
-                            getdisplay().setCursor(x0+25, y0+70);
+                            getdisplay().setCursor(x0+23, y0+79);
                         else
-                            getdisplay().setCursor(x0+65, y0+70);
+                            getdisplay().setCursor(x0+65, y0+79);
                         }
     
             // Show bus data

--- a/lib/obp60task/platformio.ini
+++ b/lib/obp60task/platformio.ini
@@ -170,5 +170,5 @@ build_flags=
     ${env.build_flags}
 upload_port = /dev/ttyUSB0          #OBP40 download via external USB/Serail converter
 upload_protocol = esptool           #firmware upload via USB OTG seriell, by first upload need to set the ESP32-S3 in the upload mode with shortcut GND to Pin27
-upload_speed = 921600
+upload_speed = 230400
 monitor_speed = 115200

--- a/lib/obp60task/platformio.ini
+++ b/lib/obp60task/platformio.ini
@@ -170,5 +170,5 @@ build_flags=
     ${env.build_flags}
 upload_port = /dev/ttyUSB0          #OBP40 download via external USB/Serail converter
 upload_protocol = esptool           #firmware upload via USB OTG seriell, by first upload need to set the ESP32-S3 in the upload mode with shortcut GND to Pin27
-upload_speed = 230400
+upload_speed = 921600
 monitor_speed = 115200


### PR DESCRIPTION
Long boat data and unit names create some overlap and mis-alignment on page SixValues.
4-digit pressure values overlap, as well.
Fixed this by some changed data arrangement, incl. more precise alignment. Still not working for a variety of values, e.g. negative roll/pitch or temperature values.

Before:
    <img width="400" height="300" alt="Page_SixValues I" src="https://github.com/user-attachments/assets/f3e0874c-f526-44b9-9c12-25d0877c1d70" />

After:
    <img width="400" height="300" alt="Page_SixValues II" src="https://github.com/user-attachments/assets/04a5bd52-6665-4f60-ba08-db60932c10ee" />
